### PR TITLE
fixing gradle `npmInstall` task to use `ci` instead of `install` and have reproducible builds without chaning package-lock.json

### DIFF
--- a/buildSrc/src/main/kotlin/SaFrontendPlugin.kt
+++ b/buildSrc/src/main/kotlin/SaFrontendPlugin.kt
@@ -13,7 +13,7 @@ class SaFrontendPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
         val npmInstall = project.tasks.register("npmInstall", SaNpmTask::class.java) {
-            args.set("install")
+            args.set("ci")
             outputDirectories.from(project.file("node_modules"))
         }
 


### PR DESCRIPTION
closes #270