### PR TITLE
Assert validation notifications and update expected default converted amount in expense tests

### DIFF
--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/expenses/CreateExpenseFullStackTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/expenses/CreateExpenseFullStackTest.kt
@@ -354,6 +354,7 @@ class CreateExpenseFullStackTest : SaFullStackTestBase() {
 
             // Submit again to trigger validation on conditional fields
             saveButton.click()
+            shouldHaveNotifications { validationFailed() }
 
             // Conditionally rendered field should be visible and may have validation errors
             convertedAmountInDefaultCurrency("USD").shouldBeVisible()
@@ -366,6 +367,7 @@ class CreateExpenseFullStackTest : SaFullStackTestBase() {
 
             // Submit again to check tax amount field validation
             saveButton.click()
+            shouldHaveNotifications { validationFailed() }
 
             // Tax amount field should now be visible
             incomeTaxableAmountInDefaultCurrency("USD").shouldBeVisible()

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/expenses/ExpensesOverviewFullStackTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/expenses/ExpensesOverviewFullStackTest.kt
@@ -792,7 +792,7 @@ class ExpensesOverviewFullStackTest : SaFullStackTestBase() {
             }
 
             convertedAmountInDefaultCurrency("USD").shouldBeVisible()
-            convertedAmountInDefaultCurrency("USD").input.shouldHaveValue("")
+            convertedAmountInDefaultCurrency("USD").input.shouldHaveValue("0.00")
 
             useDifferentExchangeRateForIncomeTaxPurposes().shouldNotBeChecked()
             incomeTaxableAmountInDefaultCurrency("USD").shouldBeHidden()


### PR DESCRIPTION
### Motivation

- Ensure validation notifications are asserted after save attempts in the create-expense flow and update expectations to match the UI's default converted amount value.

### Description

- Added `shouldHaveNotifications { validationFailed() }` assertions after `saveButton.click()` in `CreateExpenseFullStackTest.kt` to verify validation notifications are shown for conditional fields and subsequent saves.
- Updated the expectation in `ExpensesOverviewFullStackTest.kt` for `convertedAmountInDefaultCurrency("USD").input.shouldHaveValue` from an empty string to `"0.00"` to reflect the current UI default.

### Testing

- Ran `CreateExpenseFullStackTest` and `ExpensesOverviewFullStackTest` and both tests passed.
- No other automated tests were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f174ff95a48320a3cbe0867948d2cd)