### PR TITLE
Simplify expense loading by spreading loaded data into form values in EditExpense.vue

### DIFF
--- a/frontend/src/pages/expenses/EditExpense.vue
+++ b/frontend/src/pages/expenses/EditExpense.vue
@@ -284,13 +284,9 @@
     if (loaded) {
       formValues.value = {
         ...formValues.value,
+        ...loaded,
         categoryId: loaded.category?.id ?? null,
-        title: loaded.title,
-        currency: loaded.currency,
-        originalAmount: loaded.originalAmount,
-        useDifferentExchangeRateForIncomeTaxPurposes: loaded.useDifferentExchangeRateForIncomeTaxPurposes,
         notes: loaded.notes ?? null,
-        percentOnBusiness: loaded.percentOnBusiness,
         generalTaxId: loaded.generalTaxId ?? null,
         attachments: isEdit ? setDocuments(loaded.attachments) : [],
         ...(isEdit ? {


### PR DESCRIPTION
### Motivation
- Reduce repetitive field assignment when populating the expense edit form and ensure newly added fields on the expense model are included automatically by using a spread instead of enumerating each property.

### Description
- Replace explicit assignments of individual fields with `...loaded` when setting `formValues.value` inside `loadExpense`, while keeping `categoryId`, `generalTaxId`, `notes`, attachments via `setDocuments`, and the conditional `datePaid`/converted amounts logic intact, and preserve `uiState.partialForBusiness` handling.

### Testing
- Ran frontend automated checks including type checking and unit tests with `yarn test` and linting with `yarn lint`, and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a70f349c8320a0aa2ffd447fadd0)