### PR TITLE
Upgrade git-semver plugin to support linked worktrees

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 awaitility = "4.3.0"
 rerunnerJupiter = "2.1.6"
 dsgCodegen = "8.4.3"
-# version pinned as newer has major JGit changed which is not compatible with jreleaser
-gitSemverPlugin = "0.13.0"
+# 0.18.0 brings in JGit 7.x, which supports linked worktrees.
+gitSemverPlugin = "0.18.0"
 graphqlKotlin = "9.2.0"
 guava = "33.6.0-jre"
 javaxEl = "3.0.1-b12"


### PR DESCRIPTION
## Summary
- Bump `gitSemverPlugin` from `0.13.0` to `0.18.0`
- Update the pinned version note to reflect the JGit 7.x compatibility that enables linked worktrees

## Rationale
The previous version was pinned because newer releases pulled in an incompatible JGit major version. This upgrade moves to a release that works with linked worktrees while keeping the build tooling compatible.

## Notes
- No application code changes
- Dependency version only