### PR TITLE
build: default frontend build flag to false

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -175,13 +175,15 @@ val copyFrontendTask = tasks.register<Copy>("copyFrontend") {
     into("build/resources/main")
 }
 
-val forceSimpleAccountingFrontendBuild: Boolean? by project
+val forceSimpleAccountingFrontendBuild = providers.gradleProperty("forceSimpleAccountingFrontendBuild")
+    .map(String::toBoolean)
+    .getOrElse(false)
 tasks.withType<KotlinCompile> {
     ifCi {
         dependsOn(copyFrontendTask)
     }
     ifLocal {
-        if (forceSimpleAccountingFrontendBuild == true) {
+        if (forceSimpleAccountingFrontendBuild) {
             dependsOn(copyFrontendTask)
         }
     }


### PR DESCRIPTION
## Summary
- Read `forceSimpleAccountingFrontendBuild` from Gradle properties with a boolean default
- Simplify the Kotlin compile task condition to use the resolved flag directly

## Notes
- Keeps local frontend build copying opt-in unless the property is explicitly enabled