### PR TITLE
feat: Expose configuration via SA_* environment variables

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -212,7 +212,7 @@ tasks.register<Test>("updateGraphqlSchema") {
         includeTestsMatching("*GraphqlSchemaTest*")
     }
 
-    systemProperty("simpleaccounting.graphql.updateSchema", "true")
+    systemProperty("sa.graphql.updateSchema", "true")
 
     // Ensure the test runs even if it was previously successful
     outputs.upToDateWhen { false }

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/gdrive/impl/GoogleDriveApiAdapter.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/gdrive/impl/GoogleDriveApiAdapter.kt
@@ -26,7 +26,7 @@ private val log = mu.KotlinLogging.logger {}
 @Component
 class GoogleDriveApiAdapter(
     private val webClientBuilderProvider: OAuth2WebClientBuilderProvider,
-    @Value("\${simpleaccounting.documents.storage.google-drive.base-api-url}") private val baseApiUrl: String
+    @Value("\${sa.documents.storage.google-drive.base-api-url}") private val baseApiUrl: String
 ) {
 
     suspend fun uploadFile(

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/local/LocalFileSystemDocumentsStorageProperties.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/local/LocalFileSystemDocumentsStorageProperties.kt
@@ -4,7 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.stereotype.Component
 import java.nio.file.Path
 
-@ConfigurationProperties(prefix = "simpleaccounting.documents.storage.local-fs")
+@ConfigurationProperties(prefix = "sa.documents.storage.local-fs")
 @Component
 class LocalFileSystemDocumentsStorageProperties {
 

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/users/UserManagementProperties.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/users/UserManagementProperties.kt
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component
 /**
  * Configuration properties for user management.
  */
-@ConfigurationProperties("simpleaccounting.user-management")
+@ConfigurationProperties("sa.user-management")
 @Component
 data class UserManagementProperties(
     /**

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/SimpleAccountingProperties.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/SimpleAccountingProperties.kt
@@ -3,7 +3,7 @@ package io.orangebuffalo.simpleaccounting.infra
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.stereotype.Component
 
-@ConfigurationProperties("simpleaccounting")
+@ConfigurationProperties("sa")
 @Component
 data class SimpleAccountingProperties(
     var publicUrl: String = "",

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/backups/BackupProperties.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/backups/BackupProperties.kt
@@ -3,7 +3,7 @@ package io.orangebuffalo.simpleaccounting.infra.backups
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.stereotype.Component
 
-@ConfigurationProperties("simpleaccounting.backup")
+@ConfigurationProperties("sa.backup")
 @Component
 data class BackupProperties(
     var enabled: Boolean = false,

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/backups/BackupsConfig.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/backups/BackupsConfig.kt
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 class BackupsConfig {
 
-    @ConditionalOnProperty("simpleaccounting.backup.dropbox.active", havingValue = "true")
+    @ConditionalOnProperty("sa.backup.dropbox.active", havingValue = "true")
     @Configuration
     class DropboxBackupConfig {
         @Bean

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/backups/SystemDataBackupService.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/backups/SystemDataBackupService.kt
@@ -26,7 +26,7 @@ class SystemDataBackupService(
     private val backupProperties: BackupProperties,
 ) {
 
-    @Scheduled(fixedDelayString = "\${simpleaccounting.backup.scheduling-delay-in-hours}", timeUnit = TimeUnit.HOURS)
+    @Scheduled(fixedDelayString = "\${sa.backup.scheduling-delay-in-hours}", timeUnit = TimeUnit.HOURS)
     fun executeBackup() = runBlocking {
         if (!backupProperties.enabled) {
             logger.info { "Backup is disabled" }

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/backups/impl/DropboxBackupProvider.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/backups/impl/DropboxBackupProvider.kt
@@ -30,7 +30,7 @@ class DropboxBackupProvider(
         val refreshToken = backupProperties.dropbox.refreshToken
         val clientId = backupProperties.dropbox.clientId
         val clientSecret = backupProperties.dropbox.clientSecret
-        require(accessToken != null && refreshToken != null && clientId != null && clientSecret != null) {
+        require(!accessToken.isNullOrBlank() && !refreshToken.isNullOrBlank() && !clientId.isNullOrBlank() && !clientSecret.isNullOrBlank()) {
             "Dropbox tokens are not configured"
         }
         DropboxApiClient(

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -5,6 +5,8 @@ spring:
 
   datasource:
     url: jdbc:h2:/data/db/simple-accounting
+    username: "${sa.database.username}"
+    password: "${sa.database.password}"
 
   security:
     oauth2:
@@ -14,9 +16,9 @@ spring:
             provider: "google"
             scope:
               - "https://www.googleapis.com/auth/drive.file"
-            redirect-uri: "${simpleaccounting.public-url}/oauth-callback"
-            client-id: "<replace>"
-            client-secret: "<replace>"
+            redirect-uri: "${sa.public-url}/oauth-callback"
+            client-id: "${sa.documents.storage.google-drive.client-id}"
+            client-secret: "${sa.documents.storage.google-drive.client-secret}"
 
   jpa:
     properties:
@@ -36,19 +38,29 @@ server:
     whitelabel:
       enabled: false
 
-simpleaccounting:
+sa:
   public-url: "https://simple-accounting.orange-buffalo.io"
+  database:
+    username: "sa"
+    password: ""
   documents:
     storage:
       local-fs:
+        enabled: false
         base-directory: /data/documents-storage/local
       google-drive:
         base-api-url: "https://www.googleapis.com"
+        client-id: "<replace>"
+        client-secret: "<replace>"
   backup:
     enabled: false
     scheduling-delay-in-hours: 12
     dropbox:
       active: false
+      access-token: ""
+      refresh-token: ""
+      client-id: ""
+      client-secret: ""
 graphql:
   packages:
     - "io.orangebuffalo.simpleaccounting"
@@ -80,7 +92,7 @@ spring:
     activate:
       on-profile: development
 
-simpleaccounting:
+sa:
   documents:
     storage:
       local-fs:

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/infra/graphql/GraphqlSchemaTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/infra/graphql/GraphqlSchemaTest.kt
@@ -27,7 +27,7 @@ class GraphqlSchemaTest(
             .expectStatus().isOk
             .expectBody<String>().consumeWith { body ->
                 val actualSchema = body.responseBody.shouldNotBeNull()
-                val shouldOverrideSchema = System.getProperty("simpleaccounting.graphql.updateSchema")?.toBoolean()
+                val shouldOverrideSchema = System.getProperty("sa.graphql.updateSchema")?.toBoolean()
                         ?: TestConfig.instance.apiContracts.overrideCommittedSchema
 
                 if (shouldOverrideSchema) {

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/tests/infra/thirdparty/GoogleDriveApiMocks.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/tests/infra/thirdparty/GoogleDriveApiMocks.kt
@@ -15,7 +15,7 @@ object GoogleDriveApiMocks {
     private const val GDRIVE_MOCKS_ROOT_PATH = "/google-drive-mocks"
 
     fun configProperties() = arrayOf(
-        "simpleaccounting.documents.storage.google-drive.base-api-url=" +
+        "sa.documents.storage.google-drive.base-api-url=" +
                 "http://localhost:${wireMockServer.port()}$GDRIVE_MOCKS_ROOT_PATH"
     )
 

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/tests/infra/ui/FullStackTestsEnvironment.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/tests/infra/ui/FullStackTestsEnvironment.kt
@@ -80,7 +80,7 @@ class FullStackTestsSpringContextInitializer : ApplicationContextInitializer<Con
         TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
             applicationContext,
             "server.port=$springContextPort",
-            "simpleaccounting.public-url=$browserUrl",
+            "sa.public-url=$browserUrl",
         )
     }
 }

--- a/app/src/test/resources/application-test.yml
+++ b/app/src/test/resources/application-test.yml
@@ -1,4 +1,4 @@
-simpleaccounting:
+sa:
   documents:
     storage:
       local-fs:

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -13,7 +13,7 @@ This URL must be the address that **end users** use to reach the application —
 
 For example, if the application is behind a reverse proxy at `https://accounting.example.com`, configure:
 
-* `SIMPLEACCOUNTING_PUBLIC_URL` = `https://accounting.example.com`
+* `SA_PUBLIC_URL` = `https://accounting.example.com`
 
 If running locally on the default port, use `http://localhost:9393`.
 
@@ -48,16 +48,16 @@ We use automatic schema migration, so the database will be updated to the latest
 
 We highly recommend providing the following environment parameters to change the default credentials for the database:
 
-* `SPRING_DATASOURCE_PASSWORD` - database password.
-* `SPRING_DATASOURCE_USERNAME` - database username.
+* `SA_DATABASE_PASSWORD` - database password.
+* `SA_DATABASE_USERNAME` - database username.
 
 ### Google Drive integration
 
-Simple Accounting can Google Drive to store related documents. To enable this feature, you need to provide
+Simple Accounting can use Google Drive to store related documents. To enable this feature, you need to provide
 the following environment parameters:
 
-* `SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_GOOGLE-DRIVE_CLIENT-ID` - Google Drive client ID.
-* `SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_GOOGLE-DRIVE_CLIENT-SECRET` - Google Drive client secret.
+* `SA_DOCUMENTS_STORAGE_GOOGLE_DRIVE_CLIENT_ID` - Google Drive client ID.
+* `SA_DOCUMENTS_STORAGE_GOOGLE_DRIVE_CLIENT_SECRET` - Google Drive client secret.
 
 #### Setting up Google Drive client
 
@@ -83,21 +83,21 @@ base directory is on a persistent volume (for example under `/data`, which is al
 
 The feature is disabled by default. Enable it and set the base directory with these environment parameters:
 
-* `SIMPLEACCOUNTING_DOCUMENTS_STORAGE_LOCAL_FS_ENABLED` = `true` — enable local file system storage (default: `false`).
-* `SIMPLEACCOUNTING_DOCUMENTS_STORAGE_LOCAL_FS_BASE_DIRECTORY` — absolute path to the directory where documents will
-  be stored. There is no default; this property must be set when the feature is enabled.
+* `SA_DOCUMENTS_STORAGE_LOCAL_FS_ENABLED` = `true` — enable local file system storage (default: `false`).
+* `SA_DOCUMENTS_STORAGE_LOCAL_FS_BASE_DIRECTORY` — absolute path to the directory where documents will
+  be stored (default: `/data/documents-storage/local`).
 
 ### Enabling backups
 
 Simple Accounting can automatically backup the database to Dropbox. To enable this feature, you need to provide
 the following environment parameters:
 
-* `SIMPLEACCOUNTING_BACKUP_ENABLED` = `true` - enable backups.
-* `SIMPLEACCOUNTING_BACKUP_DROPBOX_ACTIVE` = `true` - enable Dropbox backup.
-* `SIMPLEACCOUNTING_BACKUP_DROPBOX_ACCESSTOKEN` - Dropbox access token.
-* `SIMPLEACCOUNTING_BACKUP_DROPBOX_REFRESHTOKEN` - Dropbox refresh token.
-* `SIMPLEACCOUNTING_BACKUP_DROPBOX_CLIENTID` - Dropbox client ID.
-* `SIMPLEACCOUNTING_BACKUP_DROPBOX_CLIENTSECRET` - Dropbox client secret.
+* `SA_BACKUP_ENABLED` = `true` - enable backups.
+* `SA_BACKUP_DROPBOX_ACTIVE` = `true` - enable Dropbox backup.
+* `SA_BACKUP_DROPBOX_ACCESSTOKEN` - Dropbox access token.
+* `SA_BACKUP_DROPBOX_REFRESHTOKEN` - Dropbox refresh token.
+* `SA_BACKUP_DROPBOX_CLIENTID` - Dropbox client ID.
+* `SA_BACKUP_DROPBOX_CLIENTSECRET` - Dropbox client secret.
 
 Refer to [Dropbox docs](https://www.dropbox.com/developers/reference/developer-guide) for how to setup the app
 and get the credentials. You can then use


### PR DESCRIPTION
## Summary
- Rename Simple Accounting-owned configuration namespace from `simpleaccounting.*` to `sa.*`.
- Expose documented deployment settings through `SA_*` environment variables using Spring relaxed binding.
- Update deployment docs for public URL, database credentials, document storage, and backup configuration.

## Why
- Avoids documenting Spring Boot internal configuration keys as the user-facing deployment API.
- Provides a shorter, stable `SA_*` configuration surface for self-hosted deployments.
- Keeps internal Spring datasource and OAuth wiring backed by application-owned properties.

## Testing
- `./gradlew :app:compileKotlin :app:compileTestKotlin --console=plain`
- `./gradlew :app:test --tests "io.orangebuffalo.simpleaccounting.business.users.migration.AdminUserRecoveryServiceTest" --console=plain`
- Verified docs/config no longer expose documented `SPRING_*` or `SIMPLEACCOUNTING_*` environment variables.