### PR TITLE
refactor: Migrate domain entities to immutable data classes

### DIFF
--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/categories/EditCategoryMutation.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/categories/EditCategoryMutation.kt
@@ -39,11 +39,13 @@ class EditCategoryMutation(
         val category = categoriesService.getCategoryByIdAndWorkspace(id, workspaceId)
             ?: throw EntityNotFoundException("Category $id is not found")
 
-        category.name = name
-        category.description = description
-        category.income = income
-        category.expense = expense
-
-        return categoriesService.saveCategory(category).toCategoryGqlDto()
+        return categoriesService.saveCategory(
+            category.copy(
+                name = name,
+                description = description,
+                income = income,
+                expense = expense,
+            )
+        ).toCategoryGqlDto()
     }
 }

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/customers/EditCustomerMutation.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/customers/EditCustomerMutation.kt
@@ -32,8 +32,6 @@ class EditCustomerMutation(
         val customer = customersService.getCustomerByIdAndWorkspace(id, workspaceId)
             ?: throw EntityNotFoundException("Customer $id is not found")
 
-        customer.name = name
-
-        return customersService.saveCustomer(customer).toCustomerGqlDto()
+        return customersService.saveCustomer(customer.copy(name = name)).toCustomerGqlDto()
     }
 }

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/expenses/EditExpenseMutation.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/expenses/EditExpenseMutation.kt
@@ -63,26 +63,28 @@ class EditExpenseMutation(
         val expense = expenseService.getExpenseByIdAndWorkspace(id, workspaceId)
             ?: throw EntityNotFoundException("Expense $id is not found")
 
-        expense.categoryId = categoryId
-        expense.title = title
-        expense.datePaid = datePaid
-        expense.currency = currency
-        expense.originalAmount = originalAmount
-        expense.convertedAmounts = AmountsInDefaultCurrency(
-            originalAmountInDefaultCurrency = convertedAmountInDefaultCurrency,
-            adjustedAmountInDefaultCurrency = null,
-        )
-        expense.incomeTaxableAmounts = AmountsInDefaultCurrency(
-            originalAmountInDefaultCurrency = incomeTaxableAmountInDefaultCurrency,
-            adjustedAmountInDefaultCurrency = null,
-        )
-        expense.useDifferentExchangeRateForIncomeTaxPurposes = useDifferentExchangeRateForIncomeTaxPurposes
-        expense.notes = notes
-        expense.percentOnBusiness = percentOnBusiness ?: 100
-        expense.attachments = mapAttachments(attachments)
-        expense.generalTaxId = generalTaxId
-
-        return expenseService.saveExpense(expense).toExpenseGqlDto()
+        return expenseService.saveExpense(
+            expense.copy(
+                categoryId = categoryId,
+                title = title,
+                datePaid = datePaid,
+                currency = currency,
+                originalAmount = originalAmount,
+                convertedAmounts = AmountsInDefaultCurrency(
+                    originalAmountInDefaultCurrency = convertedAmountInDefaultCurrency,
+                    adjustedAmountInDefaultCurrency = null,
+                ),
+                incomeTaxableAmounts = AmountsInDefaultCurrency(
+                    originalAmountInDefaultCurrency = incomeTaxableAmountInDefaultCurrency,
+                    adjustedAmountInDefaultCurrency = null,
+                ),
+                useDifferentExchangeRateForIncomeTaxPurposes = useDifferentExchangeRateForIncomeTaxPurposes,
+                notes = notes,
+                percentOnBusiness = percentOnBusiness ?: 100,
+                attachments = mapAttachments(attachments),
+                generalTaxId = generalTaxId,
+            )
+        ).toExpenseGqlDto()
     }
 
     private fun mapAttachments(attachmentIds: List<String>?): Set<ExpenseAttachment> =

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/generaltaxes/EditGeneralTaxMutation.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/generaltaxes/EditGeneralTaxMutation.kt
@@ -41,10 +41,12 @@ class EditGeneralTaxMutation(
         val tax = generalTaxesService.getTaxByIdAndWorkspace(id, workspaceId)
             ?: throw EntityNotFoundException("GeneralTax $id is not found")
 
-        tax.title = title
-        tax.description = description
-        tax.rateInBps = rateInBps
-
-        return generalTaxesService.saveTax(tax).toGeneralTaxGqlDto()
+        return generalTaxesService.saveTax(
+            tax.copy(
+                title = title,
+                description = description,
+                rateInBps = rateInBps,
+            )
+        ).toGeneralTaxGqlDto()
     }
 }

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/incomes/EditIncomeMutation.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/incomes/EditIncomeMutation.kt
@@ -59,26 +59,28 @@ class EditIncomeMutation(
         val income = incomesService.getIncomeByIdAndWorkspaceId(id, workspaceId)
             ?: throw EntityNotFoundException("Income $id is not found")
 
-        income.categoryId = categoryId
-        income.title = title
-        income.dateReceived = dateReceived
-        income.currency = currency
-        income.originalAmount = originalAmount
-        income.convertedAmounts = AmountsInDefaultCurrency(
-            originalAmountInDefaultCurrency = convertedAmountInDefaultCurrency,
-            adjustedAmountInDefaultCurrency = null,
-        )
-        income.incomeTaxableAmounts = AmountsInDefaultCurrency(
-            originalAmountInDefaultCurrency = incomeTaxableAmountInDefaultCurrency,
-            adjustedAmountInDefaultCurrency = null,
-        )
-        income.useDifferentExchangeRateForIncomeTaxPurposes = useDifferentExchangeRateForIncomeTaxPurposes
-        income.notes = notes
-        income.attachments = mapAttachments(attachments)
-        income.generalTaxId = generalTaxId
-        income.linkedInvoiceId = linkedInvoiceId
-
-        return incomesService.saveIncome(income).toIncomeGqlDto()
+        return incomesService.saveIncome(
+            income.copy(
+                categoryId = categoryId,
+                title = title,
+                dateReceived = dateReceived,
+                currency = currency,
+                originalAmount = originalAmount,
+                convertedAmounts = AmountsInDefaultCurrency(
+                    originalAmountInDefaultCurrency = convertedAmountInDefaultCurrency,
+                    adjustedAmountInDefaultCurrency = null,
+                ),
+                incomeTaxableAmounts = AmountsInDefaultCurrency(
+                    originalAmountInDefaultCurrency = incomeTaxableAmountInDefaultCurrency,
+                    adjustedAmountInDefaultCurrency = null,
+                ),
+                useDifferentExchangeRateForIncomeTaxPurposes = useDifferentExchangeRateForIncomeTaxPurposes,
+                notes = notes,
+                attachments = mapAttachments(attachments),
+                generalTaxId = generalTaxId,
+                linkedInvoiceId = linkedInvoiceId,
+            )
+        ).toIncomeGqlDto()
     }
 
     private fun mapAttachments(attachmentIds: List<String>?): Set<IncomeAttachment> =

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/incometaxpayments/EditIncomeTaxPaymentMutation.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/incometaxpayments/EditIncomeTaxPaymentMutation.kt
@@ -47,14 +47,16 @@ class EditIncomeTaxPaymentMutation(
         val payment = incomeTaxPaymentService.getTaxPaymentByIdAndWorkspace(id, workspaceId)
             ?: throw EntityNotFoundException("IncomeTaxPayment $id is not found")
 
-        payment.title = title
-        payment.datePaid = datePaid
-        payment.reportingDate = reportingDate ?: datePaid
-        payment.amount = amount
-        payment.notes = notes
-        payment.attachments = mapAttachments(attachments)
-
-        return incomeTaxPaymentService.saveTaxPayment(payment).toIncomeTaxPaymentGqlDto()
+        return incomeTaxPaymentService.saveTaxPayment(
+            payment.copy(
+                title = title,
+                datePaid = datePaid,
+                reportingDate = reportingDate ?: datePaid,
+                amount = amount,
+                notes = notes,
+                attachments = mapAttachments(attachments),
+            )
+        ).toIncomeTaxPaymentGqlDto()
     }
 
     private fun mapAttachments(attachmentIds: List<String>?): Set<IncomeTaxPaymentAttachment> =

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/invoices/EditInvoiceMutation.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/invoices/EditInvoiceMutation.kt
@@ -56,19 +56,22 @@ class EditInvoiceMutation(
         val invoice = invoicesService.getInvoiceByIdAndWorkspaceId(id, workspaceId)
             ?: throw EntityNotFoundException("Invoice $id is not found")
 
-        invoice.customerId = customerId
-        invoice.title = title
-        invoice.dateIssued = dateIssued
-        invoice.dateSent = dateSent
-        invoice.datePaid = datePaid
-        invoice.dueDate = dueDate
-        invoice.currency = currency
-        invoice.amount = amount
-        invoice.notes = notes
-        invoice.attachments = mapAttachments(attachments)
-        invoice.generalTaxId = generalTaxId
-
-        return invoicesService.saveInvoice(invoice, workspaceId).toInvoiceGqlDto(workspaceId)
+        return invoicesService.saveInvoice(
+            invoice.copy(
+                customerId = customerId,
+                title = title,
+                dateIssued = dateIssued,
+                dateSent = dateSent,
+                datePaid = datePaid,
+                dueDate = dueDate,
+                currency = currency,
+                amount = amount,
+                notes = notes,
+                attachments = mapAttachments(attachments),
+                generalTaxId = generalTaxId,
+            ),
+            workspaceId,
+        ).toInvoiceGqlDto(workspaceId)
     }
 
     private fun mapAttachments(attachmentIds: List<String>?): Set<InvoiceAttachment> =

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/profile/UpdateUserProfileMutation.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/profile/UpdateUserProfileMutation.kt
@@ -31,10 +31,15 @@ class UpdateUserProfileMutation(
         language: String,
     ): UserProfile {
         val user = platformUsersService.getCurrentUser()
-        user.documentsStorage = documentsStorage
-        user.i18nSettings.language = language
-        user.i18nSettings.locale = locale
-        val savedUser = platformUsersService.save(user)
+        val savedUser = platformUsersService.save(
+            user.copy(
+                documentsStorage = documentsStorage,
+                i18nSettings = user.i18nSettings.copy(
+                    locale = locale,
+                    language = language,
+                )
+            )
+        )
         return UserProfile(
             userName = savedUser.userName,
             documentsStorage = savedUser.documentsStorage,

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/users/EditUserMutation.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/users/EditUserMutation.kt
@@ -34,7 +34,6 @@ class EditUserMutation(
         userName: String,
     ): PlatformUserGqlDto {
         val user = platformUsersService.getUserByUserId(id)
-        user.userName = userName
-        return platformUsersService.updateUser(user).toPlatformUserGqlDto()
+        return platformUsersService.updateUser(user.copy(userName = userName)).toPlatformUserGqlDto()
     }
 }

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/workspaces/EditWorkspaceMutation.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/workspaces/EditWorkspaceMutation.kt
@@ -28,7 +28,6 @@ class EditWorkspaceMutation(
         name: String,
     ): WorkspaceGqlDto {
         val workspace = workspacesService.getAccessibleWorkspace(id, WorkspaceAccessMode.ADMIN)
-        workspace.name = name
-        return workspacesService.save(workspace).toWorkspaceGqlDto()
+        return workspacesService.save(workspace.copy(name = name)).toWorkspaceGqlDto()
     }
 }

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/categories/Category.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/categories/Category.kt
@@ -2,12 +2,16 @@ package io.orangebuffalo.simpleaccounting.business.categories
 
 import io.orangebuffalo.simpleaccounting.business.common.pesistence.AbstractEntity
 import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
 
 @Table
-class Category(
-    var name: String,
-    var description: String? = null,
+data class Category(
+    val name: String,
+    val description: String? = null,
     val workspaceId: String,
-    var income: Boolean,
-    var expense: Boolean
+    val income: Boolean,
+    val expense: Boolean,
+    override val id: String? = null,
+    override val version: Int? = null,
+    override val createdAt: Instant? = null,
 ) : AbstractEntity()

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/common/data/AmountsInDefaultCurrency.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/common/data/AmountsInDefaultCurrency.kt
@@ -6,14 +6,14 @@ data class AmountsInDefaultCurrency(
      * The original amount after currency conversion to the default currency.
      * If entity is already in default currency, expected to be the same as its original amount.
      */
-    var originalAmountInDefaultCurrency: Long?,
+    val originalAmountInDefaultCurrency: Long?,
 
     /**
      * Amount in default currency after all adjustments (partial business purpose, general tax, etc)
      * are applied. Is expected to be used for reporting purposes as the final amount related to the
      * entity (for instance, to be reported for income tax purposes to the Tax Office).
      */
-    var adjustedAmountInDefaultCurrency: Long?
+    val adjustedAmountInDefaultCurrency: Long?
 
 ) {
 

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/common/pesistence/AbstractEntity.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/common/pesistence/AbstractEntity.kt
@@ -1,38 +1,31 @@
 package io.orangebuffalo.simpleaccounting.business.common.pesistence
 
 import org.springframework.data.annotation.Id
-import org.springframework.data.annotation.Transient
 import org.springframework.data.annotation.Version
 import java.time.Instant
-import java.util.concurrent.atomic.AtomicLong
-
-private val stickyHashRegistry: AtomicLong = AtomicLong()
 
 abstract class AbstractEntity {
 
-    @Id
-    var id: String? = null
+    @get:Id
+    abstract val id: String?
 
-    @Version
-    var version: Int? = null
+    @get:Version
+    abstract val version: Int?
 
-    var createdAt: Instant? = null
+    abstract val createdAt: Instant?
 
-    @delegate:Transient
-    private val stickyHash: Any by lazy(LazyThreadSafetyMode.NONE) { id ?: stickyHashRegistry.incrementAndGet() }
-
-    override fun equals(other: Any?): Boolean {
+    final override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         other as AbstractEntity
-        return stickyHash == other.stickyHash
+        return id != null && id == other.id
     }
 
-    override fun hashCode(): Int {
-        return stickyHash.hashCode()
+    final override fun hashCode(): Int {
+        return id?.hashCode() ?: System.identityHashCode(this)
     }
 
-    override fun toString(): String {
+    final override fun toString(): String {
         return "[${this.javaClass.simpleName}#${this.id}/v${this.version}]"
     }
 }

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/customers/Customer.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/customers/Customer.kt
@@ -2,9 +2,13 @@ package io.orangebuffalo.simpleaccounting.business.customers
 
 import io.orangebuffalo.simpleaccounting.business.common.pesistence.AbstractEntity
 import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
 
 @Table
-class Customer(
-    var name: String,
-    val workspaceId: String
+data class Customer(
+    val name: String,
+    val workspaceId: String,
+    override val id: String? = null,
+    override val version: Int? = null,
+    override val createdAt: Instant? = null,
 ) : AbstractEntity()

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/Document.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/Document.kt
@@ -5,12 +5,15 @@ import org.springframework.data.relational.core.mapping.Table
 import java.time.Instant
 
 @Table
-class Document(
-    var name: String,
+data class Document(
+    val name: String,
     val workspaceId: String,
     val timeUploaded: Instant,
-    var storageId: String,
-    var storageLocation: String?,
+    val storageId: String,
+    val storageLocation: String?,
     val sizeInBytes: Long?,
-    val mimeType: String
+    val mimeType: String,
+    override val id: String? = null,
+    override val version: Int? = null,
+    override val createdAt: Instant? = null,
 ) : AbstractEntity()

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/gdrive/GoogleDriveDocumentsStorage.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/gdrive/GoogleDriveDocumentsStorage.kt
@@ -120,15 +120,11 @@ class GoogleDriveDocumentsStorage(
                     ?: GoogleDriveStorageIntegration(userId = user.id!!)
             }
 
-            val rootFolder = ensureRootFolder(integration)
-
-            withDbContext {
-                repository.save(integration)
-            }
+            val (rootFolder, savedIntegration) = ensureRootFolder(integration)
 
             pushNotificationService.sendPushNotification(
                 eventName = AUTH_EVENT_NAME,
-                userId = integration.userId,
+                userId = savedIntegration.userId,
                 data = GoogleDriveStorageIntegrationStatus(
                     folderId = rootFolder.id,
                     folderName = rootFolder.name,
@@ -150,7 +146,9 @@ class GoogleDriveDocumentsStorage(
             )
         }
 
-    private suspend fun ensureRootFolder(integration: GoogleDriveStorageIntegration): FolderResponse {
+    private suspend fun ensureRootFolder(
+        integration: GoogleDriveStorageIntegration
+    ): Pair<FolderResponse, GoogleDriveStorageIntegration> {
         log.debug { "Ensuring root folder for Google Drive integration $integration" }
 
         val rootFolder = try {
@@ -159,12 +157,12 @@ class GoogleDriveDocumentsStorage(
             log.debug { "Root folder not found: ${e.message}" }
             null
         }
-        return rootFolder ?: googleDriveApi
+        return rootFolder?.let { it to integration } ?: googleDriveApi
             .createFolder(folderName = "simple-accounting", parentFolderId = null)
-            .also { driveFolder ->
-                integration.folderId = driveFolder.id
-                repository.save(integration)
-                log.debug { "Root folder created $driveFolder and saved to integration $integration" }
+            .let { driveFolder ->
+                val savedIntegration = repository.save(integration.copy(folderId = driveFolder.id))
+                log.debug { "Root folder created $driveFolder and saved to integration $savedIntegration" }
+                driveFolder to savedIntegration
             }
     }
 
@@ -184,7 +182,7 @@ class GoogleDriveDocumentsStorage(
         )
 
         val rootFolder = try {
-            ensureRootFolder(integration)
+            ensureRootFolder(integration).first
         } catch (_: StorageAuthorizationRequiredException) {
             log.debug { "Authorization required for Google Drive integration" }
             return integrationStatus.copy(

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/gdrive/GoogleDriveStorageIntegration.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/gdrive/GoogleDriveStorageIntegration.kt
@@ -2,9 +2,13 @@ package io.orangebuffalo.simpleaccounting.business.documents.storage.gdrive
 
 import io.orangebuffalo.simpleaccounting.business.common.pesistence.AbstractEntity
 import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
 
 @Table
-class GoogleDriveStorageIntegration(
+data class GoogleDriveStorageIntegration(
     val userId: String,
-    var folderId: String? = null
+    val folderId: String? = null,
+    override val id: String? = null,
+    override val version: Int? = null,
+    override val createdAt: Instant? = null,
 ) : AbstractEntity()

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/expenses/Expense.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/expenses/Expense.kt
@@ -5,52 +5,53 @@ import io.orangebuffalo.simpleaccounting.business.common.data.AmountsInDefaultCu
 import org.springframework.data.relational.core.mapping.Embedded
 import org.springframework.data.relational.core.mapping.MappedCollection
 import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
 import java.time.LocalDate
 
 @Table
-class Expense(
-    var categoryId: String?,
-    var workspaceId: String,
-    var title: String,
-    var datePaid: LocalDate,
+data class Expense(
+    val categoryId: String?,
+    val workspaceId: String,
+    val title: String,
+    val datePaid: LocalDate,
 
     /**
      * Original currency of this receipt/invoice/etc.
      */
-    var currency: String,
+    val currency: String,
 
     /**
      * Amount in original currency as stated in the receipt/invoice/etc.
      */
-    var originalAmount: Long,
+    val originalAmount: Long,
 
     /**
      * Converted amounts in default currency (i.e. from bank transaction in domestic currency).
      */
     @field:Embedded.Empty(prefix = "CONVERTED_")
-    var convertedAmounts: AmountsInDefaultCurrency,
+    val convertedAmounts: AmountsInDefaultCurrency,
 
     /**
      * Indicates if [incomeTaxableAmounts] are using different exchange rate than [convertedAmounts]
      * (i.e. by using Tax Office exchange rate).
      */
-    var useDifferentExchangeRateForIncomeTaxPurposes: Boolean,
+    val useDifferentExchangeRateForIncomeTaxPurposes: Boolean,
 
     /**
      * Amounts for income tax purposes. In case [useDifferentExchangeRateForIncomeTaxPurposes]
      * is `false`, are the same as [convertedAmounts]. Otherwise amounts are different.
      */
     @field:Embedded.Empty(prefix = "INCOME_TAXABLE_")
-    var incomeTaxableAmounts: AmountsInDefaultCurrency,
+    val incomeTaxableAmounts: AmountsInDefaultCurrency,
 
     @field:MappedCollection(idColumn = "EXPENSE_ID")
-    var attachments: Set<ExpenseAttachment> = setOf(),
+    val attachments: Set<ExpenseAttachment> = setOf(),
 
-    var percentOnBusiness: Int,
+    val percentOnBusiness: Int,
 
-    var generalTaxId: String?,
+    val generalTaxId: String?,
 
-    var generalTaxRateInBps: Int? = null,
+    val generalTaxRateInBps: Int? = null,
 
     /**
      * Amount that is a part of original amount (after conversion to the default currency,
@@ -58,11 +59,14 @@ class Expense(
      * This amount is deducted from the `originalAmountInDefaultCurrency` when
      * `adjustedAmountInDefaultCurrency` is calculated.
      */
-    var generalTaxAmount: Long? = null,
+    val generalTaxAmount: Long? = null,
 
-    var notes: String? = null,
+    val notes: String? = null,
 
-    var status: ExpenseStatus
+    val status: ExpenseStatus,
+    override val id: String? = null,
+    override val version: Int? = null,
+    override val createdAt: Instant? = null,
 
 ) : AbstractEntity()
 

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/expenses/ExpenseService.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/expenses/ExpenseService.kt
@@ -32,35 +32,45 @@ class ExpenseService(
         val workspace = workspacesService.getAccessibleWorkspace(expense.workspaceId, WorkspaceAccessMode.READ_WRITE)
         validateCategoryAndAttachments(expense, workspace.id!!)
 
-        val defaultCurrency = workspace.defaultCurrency
-        if (defaultCurrency == expense.currency) {
-            expense.convertedAmounts = AmountsInDefaultCurrency(expense.originalAmount, null)
-            expense.incomeTaxableAmounts = AmountsInDefaultCurrency(expense.originalAmount, null)
-            expense.useDifferentExchangeRateForIncomeTaxPurposes = false
-        }
-
-        if (!expense.useDifferentExchangeRateForIncomeTaxPurposes) {
-            expense.incomeTaxableAmounts = expense.convertedAmounts
-        }
+        val isDefaultCurrency = workspace.defaultCurrency == expense.currency
+        val convertedAmounts = if (isDefaultCurrency) {
+            AmountsInDefaultCurrency(expense.originalAmount, null)
+        } else expense.convertedAmounts
+        val useDifferentExchangeRateForIncomeTaxPurposes =
+            !isDefaultCurrency && expense.useDifferentExchangeRateForIncomeTaxPurposes
+        val incomeTaxableAmounts = if (useDifferentExchangeRateForIncomeTaxPurposes) {
+            expense.incomeTaxableAmounts
+        } else convertedAmounts
 
         val generalTax = getGeneralTax(expense)
-        expense.generalTaxRateInBps = generalTax?.rateInBps
+        val convertedAdjustedAmounts = calculateAdjustedAmounts(expense, convertedAmounts, generalTax)
+        val adjustedConvertedAmounts = convertedAmounts.copy(
+            adjustedAmountInDefaultCurrency = convertedAdjustedAmounts.adjustedAmount
+        )
 
-        val convertedAdjustedAmounts = calculateAdjustedAmounts(expense, expense.convertedAmounts, generalTax)
-        expense.convertedAmounts.adjustedAmountInDefaultCurrency = convertedAdjustedAmounts.adjustedAmount
-
-        val incomeTaxableAdjustedAmounts = calculateAdjustedAmounts(expense, expense.incomeTaxableAmounts, generalTax)
-        expense.incomeTaxableAmounts.adjustedAmountInDefaultCurrency = incomeTaxableAdjustedAmounts.adjustedAmount
-        expense.generalTaxAmount = incomeTaxableAdjustedAmounts.generalTaxAmount
-
-        expense.status = when {
-            expense.convertedAmounts.adjustedAmountInDefaultCurrency == null -> ExpenseStatus.PENDING_CONVERSION
-            expense.incomeTaxableAmounts.adjustedAmountInDefaultCurrency == null ->
+        val incomeTaxableAdjustedAmounts = calculateAdjustedAmounts(expense, incomeTaxableAmounts, generalTax)
+        val adjustedIncomeTaxableAmounts = incomeTaxableAmounts.copy(
+            adjustedAmountInDefaultCurrency = incomeTaxableAdjustedAmounts.adjustedAmount
+        )
+        val status = when {
+            adjustedConvertedAmounts.adjustedAmountInDefaultCurrency == null -> ExpenseStatus.PENDING_CONVERSION
+            adjustedIncomeTaxableAmounts.adjustedAmountInDefaultCurrency == null ->
                 ExpenseStatus.PENDING_CONVERSION_FOR_TAXATION_PURPOSES
             else -> ExpenseStatus.FINALIZED
         }
 
-        return withDbContext { expensesRepository.save(expense) }
+        return withDbContext {
+            expensesRepository.save(
+                expense.copy(
+                    convertedAmounts = adjustedConvertedAmounts,
+                    incomeTaxableAmounts = adjustedIncomeTaxableAmounts,
+                    useDifferentExchangeRateForIncomeTaxPurposes = useDifferentExchangeRateForIncomeTaxPurposes,
+                    generalTaxRateInBps = generalTax?.rateInBps,
+                    generalTaxAmount = incomeTaxableAdjustedAmounts.generalTaxAmount,
+                    status = status,
+                )
+            )
+        }
     }
 
     private suspend fun getGeneralTax(expense: Expense): GeneralTax? =

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/generaltaxes/GeneralTax.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/generaltaxes/GeneralTax.kt
@@ -2,6 +2,7 @@ package io.orangebuffalo.simpleaccounting.business.generaltaxes
 
 import io.orangebuffalo.simpleaccounting.business.common.pesistence.AbstractEntity
 import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
 
 /**
  * [General tax](https://en.wikipedia.org/wiki/List_of_taxes) includes taxes that
@@ -9,9 +10,12 @@ import org.springframework.data.relational.core.mapping.Table
  * Sales Tax, etc. They are processed separately and not included into the income tax.
  */
 @Table
-class GeneralTax(
-    var title: String,
-    var rateInBps: Int,
-    var description: String? = null,
-    val workspaceId: String
+data class GeneralTax(
+    val title: String,
+    val rateInBps: Int,
+    val description: String? = null,
+    val workspaceId: String,
+    override val id: String? = null,
+    override val version: Int? = null,
+    override val createdAt: Instant? = null,
 ) : AbstractEntity()

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/incomes/Income.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/incomes/Income.kt
@@ -5,58 +5,62 @@ import io.orangebuffalo.simpleaccounting.business.common.data.AmountsInDefaultCu
 import org.springframework.data.relational.core.mapping.Embedded
 import org.springframework.data.relational.core.mapping.MappedCollection
 import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
 import java.time.LocalDate
 
 @Table
-class Income(
-    var categoryId: String?,
-    var workspaceId: String,
-    var title: String,
-    var dateReceived: LocalDate,
+data class Income(
+    val categoryId: String?,
+    val workspaceId: String,
+    val title: String,
+    val dateReceived: LocalDate,
 
     /**
      * Original currency of this income.
      */
-    var currency: String,
+    val currency: String,
 
     /**
      * Amount in original currency.
      */
-    var originalAmount: Long,
+    val originalAmount: Long,
 
     /**
      * Converted amounts in default currency (i.e. from bank transaction in domestic currency).
      */
     @field:Embedded.Empty(prefix = "CONVERTED_")
-    var convertedAmounts: AmountsInDefaultCurrency,
+    val convertedAmounts: AmountsInDefaultCurrency,
 
     /**
      * Indicates if [incomeTaxableAmounts] are using different exchange rate than [convertedAmounts]
      * (i.e. by using Tax Office exchange rate).
      */
-    var useDifferentExchangeRateForIncomeTaxPurposes: Boolean,
+    val useDifferentExchangeRateForIncomeTaxPurposes: Boolean,
 
     /**
      * Amounts for income tax purposes. In case [useDifferentExchangeRateForIncomeTaxPurposes]
      * is `false`, are the same as [convertedAmounts]. Otherwise amounts are different.
      */
     @field:Embedded.Empty(prefix = "INCOME_TAXABLE_")
-    var incomeTaxableAmounts: AmountsInDefaultCurrency,
+    val incomeTaxableAmounts: AmountsInDefaultCurrency,
 
     @field:MappedCollection(idColumn = "INCOME_ID")
-    var attachments: Set<IncomeAttachment> = setOf(),
+    val attachments: Set<IncomeAttachment> = setOf(),
 
-    var notes: String? = null,
+    val notes: String? = null,
 
-    var generalTaxId: String?,
+    val generalTaxId: String?,
 
-    var generalTaxRateInBps: Int? = null,
+    val generalTaxRateInBps: Int? = null,
 
-    var generalTaxAmount: Long? = null,
+    val generalTaxAmount: Long? = null,
 
-    var status: IncomeStatus,
+    val status: IncomeStatus,
 
-    var linkedInvoiceId: String? = null
+    val linkedInvoiceId: String? = null,
+    override val id: String? = null,
+    override val version: Int? = null,
+    override val createdAt: Instant? = null,
 
 ) : AbstractEntity()
 

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/incomes/IncomesService.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/incomes/IncomesService.kt
@@ -31,35 +31,45 @@ class IncomesService(
         validateCategoryAndAttachments(income)
         updateInvoiceIfLinked(income)
 
-        val defaultCurrency = workspace.defaultCurrency
-        if (defaultCurrency == income.currency) {
-            income.convertedAmounts = AmountsInDefaultCurrency(income.originalAmount, null)
-            income.incomeTaxableAmounts = AmountsInDefaultCurrency(income.originalAmount, null)
-            income.useDifferentExchangeRateForIncomeTaxPurposes = false
-        }
-
-        if (!income.useDifferentExchangeRateForIncomeTaxPurposes) {
-            income.incomeTaxableAmounts = income.convertedAmounts
-        }
+        val isDefaultCurrency = workspace.defaultCurrency == income.currency
+        val convertedAmounts = if (isDefaultCurrency) {
+            AmountsInDefaultCurrency(income.originalAmount, null)
+        } else income.convertedAmounts
+        val useDifferentExchangeRateForIncomeTaxPurposes =
+            !isDefaultCurrency && income.useDifferentExchangeRateForIncomeTaxPurposes
+        val incomeTaxableAmounts = if (useDifferentExchangeRateForIncomeTaxPurposes) {
+            income.incomeTaxableAmounts
+        } else convertedAmounts
 
         val generalTax = getGeneralTax(income)
-        income.generalTaxRateInBps = generalTax?.rateInBps
+        val convertedAdjustedAmounts = calculateAdjustedAmount(convertedAmounts, generalTax)
+        val adjustedConvertedAmounts = convertedAmounts.copy(
+            adjustedAmountInDefaultCurrency = convertedAdjustedAmounts.adjustedAmount
+        )
 
-        val convertedAdjustedAmounts = calculateAdjustedAmount(income.convertedAmounts, generalTax)
-        income.convertedAmounts.adjustedAmountInDefaultCurrency = convertedAdjustedAmounts.adjustedAmount
-
-        val incomeTaxableAdjustedAmounts = calculateAdjustedAmount(income.incomeTaxableAmounts, generalTax)
-        income.incomeTaxableAmounts.adjustedAmountInDefaultCurrency = incomeTaxableAdjustedAmounts.adjustedAmount
-        income.generalTaxAmount = incomeTaxableAdjustedAmounts.generalTaxAmount
-
-        income.status = when {
-            income.convertedAmounts.adjustedAmountInDefaultCurrency == null -> IncomeStatus.PENDING_CONVERSION
-            income.incomeTaxableAmounts.adjustedAmountInDefaultCurrency == null ->
+        val incomeTaxableAdjustedAmounts = calculateAdjustedAmount(incomeTaxableAmounts, generalTax)
+        val adjustedIncomeTaxableAmounts = incomeTaxableAmounts.copy(
+            adjustedAmountInDefaultCurrency = incomeTaxableAdjustedAmounts.adjustedAmount
+        )
+        val status = when {
+            adjustedConvertedAmounts.adjustedAmountInDefaultCurrency == null -> IncomeStatus.PENDING_CONVERSION
+            adjustedIncomeTaxableAmounts.adjustedAmountInDefaultCurrency == null ->
                 IncomeStatus.PENDING_CONVERSION_FOR_TAXATION_PURPOSES
             else -> IncomeStatus.FINALIZED
         }
 
-        return withDbContext { incomeRepository.save(income) }
+        return withDbContext {
+            incomeRepository.save(
+                income.copy(
+                    convertedAmounts = adjustedConvertedAmounts,
+                    incomeTaxableAmounts = adjustedIncomeTaxableAmounts,
+                    useDifferentExchangeRateForIncomeTaxPurposes = useDifferentExchangeRateForIncomeTaxPurposes,
+                    generalTaxRateInBps = generalTax?.rateInBps,
+                    generalTaxAmount = incomeTaxableAdjustedAmounts.generalTaxAmount,
+                    status = status,
+                )
+            )
+        }
     }
 
     private suspend fun updateInvoiceIfLinked(income: Income) {
@@ -68,8 +78,7 @@ class IncomesService(
         val invoice = invoicesService.getInvoiceByIdAndWorkspaceId(id = invoiceId, workspaceId = income.workspaceId)
             ?: throw EntityNotFoundException("Invoice $invoiceId is not found")
 
-        invoice.datePaid = income.dateReceived
-        invoicesService.saveInvoice(invoice, income.workspaceId)
+        invoicesService.saveInvoice(invoice.copy(datePaid = income.dateReceived), income.workspaceId)
     }
 
     private suspend fun getGeneralTax(income: Income): GeneralTax? =

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/incometaxpayments/IncomeTaxPayment.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/incometaxpayments/IncomeTaxPayment.kt
@@ -3,21 +3,25 @@ package io.orangebuffalo.simpleaccounting.business.incometaxpayments
 import io.orangebuffalo.simpleaccounting.business.common.pesistence.AbstractEntity
 import org.springframework.data.relational.core.mapping.MappedCollection
 import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
 import java.time.LocalDate
 
 @Table
-class IncomeTaxPayment(
+data class IncomeTaxPayment(
 
-    var workspaceId: String,
-    var datePaid: LocalDate,
-    var reportingDate: LocalDate,
-    var amount: Long,
-    var title: String,
+    val workspaceId: String,
+    val datePaid: LocalDate,
+    val reportingDate: LocalDate,
+    val amount: Long,
+    val title: String,
 
     @field:MappedCollection(idColumn = "INCOME_TAX_PAYMENT_ID")
-    var attachments: Set<IncomeTaxPaymentAttachment> = setOf(),
+    val attachments: Set<IncomeTaxPaymentAttachment> = setOf(),
 
-    var notes: String? = null
+    val notes: String? = null,
+    override val id: String? = null,
+    override val version: Int? = null,
+    override val createdAt: Instant? = null,
 
 ) : AbstractEntity()
 

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/invoices/Invoice.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/invoices/Invoice.kt
@@ -7,21 +7,24 @@ import java.time.Instant
 import java.time.LocalDate
 
 @Table
-class Invoice(
-    var customerId: String,
-    var title: String,
-    var dateIssued: LocalDate,
-    var dateSent: LocalDate? = null,
-    var datePaid: LocalDate? = null,
-    var timeCancelled: Instant? = null,
-    var dueDate: LocalDate,
-    var currency: String,
-    var amount: Long,
+data class Invoice(
+    val customerId: String,
+    val title: String,
+    val dateIssued: LocalDate,
+    val dateSent: LocalDate? = null,
+    val datePaid: LocalDate? = null,
+    val timeCancelled: Instant? = null,
+    val dueDate: LocalDate,
+    val currency: String,
+    val amount: Long,
     @field:MappedCollection(idColumn = "INVOICE_ID")
-    var attachments: Set<InvoiceAttachment> = setOf(),
-    var notes: String? = null,
-    var generalTaxId: String? = null,
-    var status: InvoiceStatus = InvoiceStatus.DRAFT
+    val attachments: Set<InvoiceAttachment> = setOf(),
+    val notes: String? = null,
+    val generalTaxId: String? = null,
+    val status: InvoiceStatus = InvoiceStatus.DRAFT,
+    override val id: String? = null,
+    override val version: Int? = null,
+    override val createdAt: Instant? = null,
 
 ) : AbstractEntity()
 

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/invoices/InvoicesService.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/invoices/InvoicesService.kt
@@ -46,10 +46,7 @@ class InvoicesService(
         logger.info { "Started moving invoices to overdue" }
         runBlocking {
             val overdueInvoices = withDbContext { invoicesRepository.findAllOverdue() }
-            overdueInvoices.forEach { invoice ->
-                invoice.status = InvoiceStatus.OVERDUE
-            }
-            withDbContext { invoicesRepository.saveAll(overdueInvoices) }
+            withDbContext { invoicesRepository.saveAll(overdueInvoices.map { it.copy(status = InvoiceStatus.OVERDUE) }) }
         }
         logger.info { "All eligible invoices moved to overdue state" }
     }
@@ -59,8 +56,7 @@ class InvoicesService(
      */
     suspend fun saveInvoice(invoice: Invoice, workspaceId: String): Invoice {
         validateInvoice(invoice, workspaceId)
-        updateInvoiceStatus(invoice)
-        return withDbContext { invoicesRepository.save(invoice) }
+        return withDbContext { invoicesRepository.save(updateInvoiceStatus(invoice)) }
     }
 
     suspend fun cancelInvoice(invoiceId: String, workspaceId: String): Invoice {
@@ -79,23 +75,26 @@ class InvoicesService(
             throw EntityNotFoundException("Invoice $invoiceId is not found")
         }
 
-        invoice.status = InvoiceStatus.CANCELLED
-        invoice.timeCancelled = timeService.currentTime()
-        return withDbContext { invoicesRepository.save(invoice) }
+        return withDbContext {
+            invoicesRepository.save(
+                invoice.copy(
+                    status = InvoiceStatus.CANCELLED,
+                    timeCancelled = timeService.currentTime(),
+                )
+            )
+        }
     }
 
-    private fun updateInvoiceStatus(invoice: Invoice) {
-        if (invoice.status != InvoiceStatus.CANCELLED) {
-            if (invoice.datePaid != null) {
-                invoice.status = InvoiceStatus.PAID
-            } else if (invoice.dateSent != null && isOverdue(invoice)) {
-                invoice.status = InvoiceStatus.OVERDUE
-            } else if (invoice.dateSent != null) {
-                invoice.status = InvoiceStatus.SENT
-            } else {
-                invoice.status = InvoiceStatus.DRAFT
-            }
-        }
+    private fun updateInvoiceStatus(invoice: Invoice): Invoice = if (invoice.status == InvoiceStatus.CANCELLED) {
+        invoice
+    } else if (invoice.datePaid != null) {
+        invoice.copy(status = InvoiceStatus.PAID)
+    } else if (invoice.dateSent != null && isOverdue(invoice)) {
+        invoice.copy(status = InvoiceStatus.OVERDUE)
+    } else if (invoice.dateSent != null) {
+        invoice.copy(status = InvoiceStatus.SENT)
+    } else {
+        invoice.copy(status = InvoiceStatus.DRAFT)
     }
 
     private fun isOverdue(invoice: Invoice) = invoice.dueDate.isBefore(timeService.currentDate())

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/security/authentication/AuthenticationService.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/security/authentication/AuthenticationService.kt
@@ -1,5 +1,6 @@
 package io.orangebuffalo.simpleaccounting.business.security.authentication
 
+import io.orangebuffalo.simpleaccounting.business.users.LoginStatistics
 import io.orangebuffalo.simpleaccounting.business.users.PlatformUsersService
 import io.orangebuffalo.simpleaccounting.infra.TimeService
 import io.orangebuffalo.simpleaccounting.business.users.PlatformUser
@@ -52,8 +53,9 @@ class AuthenticationService(
     }
 
     private suspend fun resetLoginStatistics(user: PlatformUser) {
-        user.loginStatistics.reset()
-        platformUsersService.save(user)
+        platformUsersService.save(
+            user.copy(loginStatistics = LoginStatistics(failedAttemptsCount = 0, temporaryLockExpirationTime = null))
+        )
     }
 
     private suspend fun validatePassword(
@@ -70,19 +72,26 @@ class AuthenticationService(
         passwordEncoder.matches(credentials, user.passwordHash)
 
     private suspend fun updateLoginStatisticsOnBadCredentials(user: PlatformUser) {
-        val loginStatistics = user.loginStatistics
-        loginStatistics.failedAttemptsCount++
-        if (loginStatistics.failedAttemptsCount > MAX_FAILED_ATTEMPTS_BEFORE_LOCKING) {
-            val numberOfLockingAttempts = loginStatistics.failedAttemptsCount - MAX_FAILED_ATTEMPTS_BEFORE_LOCKING
+        val failedAttemptsCount = user.loginStatistics.failedAttemptsCount + 1
+        if (failedAttemptsCount > MAX_FAILED_ATTEMPTS_BEFORE_LOCKING) {
+            val numberOfLockingAttempts = failedAttemptsCount - MAX_FAILED_ATTEMPTS_BEFORE_LOCKING
             val lockPeriodInMs = INITIAL_LOCK_PERIOD_MS.toBigDecimal()
                 .multiply(LOCKING_TIME_PROGRESSION_RATIO.pow(numberOfLockingAttempts - 1))
                 .min(MAX_LOCK_PERIOD_MS)
                 .toLong()
-            loginStatistics.temporaryLockExpirationTime = timeService.currentTime().plusMillis(lockPeriodInMs)
-            platformUsersService.save(user)
+            platformUsersService.save(
+                user.copy(
+                    loginStatistics = user.loginStatistics.copy(
+                        failedAttemptsCount = failedAttemptsCount,
+                        temporaryLockExpirationTime = timeService.currentTime().plusMillis(lockPeriodInMs),
+                    )
+                )
+            )
             throw AccountIsTemporaryLockedException(lockPeriodInMs / 1000)
         }
-        platformUsersService.save(user)
+        platformUsersService.save(
+            user.copy(loginStatistics = user.loginStatistics.copy(failedAttemptsCount = failedAttemptsCount))
+        )
     }
 
     suspend fun changeCurrentUserPassword(currentPassword: String, newPassword: String) {
@@ -96,13 +105,11 @@ class AuthenticationService(
         if (!checkCredentials(user, currentPassword)) {
             throw PasswordChangeException.InvalidCurrentPasswordException()
         }
-        setUserPassword(user, newPassword)
-        platformUsersService.save(user)
+        platformUsersService.save(setUserPassword(user, newPassword))
     }
 
-    fun setUserPassword(user: PlatformUser, password: String) {
-        user.passwordHash = passwordEncoder.encode(password)
-    }
+    fun setUserPassword(user: PlatformUser, password: String): PlatformUser =
+        user.copy(passwordHash = passwordEncoder.encode(password))
 }
 
 sealed class PasswordChangeException(message: String) : RuntimeException(message) {

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/security/remeberme/RefreshToken.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/security/remeberme/RefreshToken.kt
@@ -5,8 +5,11 @@ import org.springframework.data.relational.core.mapping.Table
 import java.time.Instant
 
 @Table
-class RefreshToken(
+data class RefreshToken(
     val userId: String,
     val token: String,
-    var expirationTime: Instant
+    val expirationTime: Instant,
+    override val id: String? = null,
+    override val version: Int? = null,
+    override val createdAt: Instant? = null,
 ) : AbstractEntity()

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/security/remeberme/RefreshTokensService.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/security/remeberme/RefreshTokensService.kt
@@ -62,8 +62,11 @@ class RefreshTokensService(
         withDbContext {
             val refreshToken = refreshTokensRepository.findByToken(refreshTokenString)
                 ?: throw IllegalArgumentException("Bad token $refreshTokenString")
-            refreshToken.expirationTime = timeService.currentTime().plus(TOKEN_LIFETIME_IN_DAYS, ChronoUnit.DAYS)
-            refreshTokensRepository.save(refreshToken)
+            refreshTokensRepository.save(
+                refreshToken.copy(
+                    expirationTime = timeService.currentTime().plus(TOKEN_LIFETIME_IN_DAYS, ChronoUnit.DAYS)
+                )
+            )
             refreshToken.token
         }
 }

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/users/PlatformUser.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/users/PlatformUser.kt
@@ -6,12 +6,12 @@ import org.springframework.data.relational.core.mapping.Table
 import java.time.Instant
 
 @Table
-class PlatformUser(
-    var userName: String,
-    var passwordHash: String,
-    var isAdmin: Boolean,
-    var activated: Boolean,
-    var documentsStorage: String? = null,
+data class PlatformUser(
+    val userName: String,
+    val passwordHash: String,
+    val isAdmin: Boolean,
+    val activated: Boolean,
+    val documentsStorage: String? = null,
 
     @field:Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
     val loginStatistics: LoginStatistics = LoginStatistics(0, null),
@@ -20,21 +20,18 @@ class PlatformUser(
     val i18nSettings: I18nSettings = I18nSettings(
         locale = "en_AU",
         language = "en"
-    )
+    ),
+    override val id: String? = null,
+    override val version: Int? = null,
+    override val createdAt: Instant? = null,
 ) : AbstractEntity()
 
 data class LoginStatistics(
-    var failedAttemptsCount: Int,
-    var temporaryLockExpirationTime: Instant?
-) {
-
-    fun reset() {
-        failedAttemptsCount = 0
-        temporaryLockExpirationTime = null
-    }
-}
+    val failedAttemptsCount: Int,
+    val temporaryLockExpirationTime: Instant?
+)
 
 data class I18nSettings(
-    var locale: String,
-    var language: String
+    val locale: String,
+    val language: String
 )

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/users/PlatformUsersService.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/users/PlatformUsersService.kt
@@ -177,11 +177,12 @@ class PlatformUsersService(
                 .orElseThrow { IllegalStateException("User ${userActivationToken.userId} is not found") }
         }
 
-        authenticationService.getObject().setUserPassword(user, password)
-        user.activated = true
+        val activatedUser = authenticationService.getObject()
+            .setUserPassword(user, password)
+            .copy(activated = true)
 
         withDbContext {
-            userRepository.save(user)
+            userRepository.save(activatedUser)
             userActivationTokensRepository.delete(userActivationToken)
         }
     }

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/users/UserActivationToken.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/users/UserActivationToken.kt
@@ -11,7 +11,7 @@ import java.time.Instant
  * The user then uses the token to activate the account and set the password.
  */
 @Table
-class UserActivationToken(
+data class UserActivationToken(
     /**
      * User this token is intended for. It is not possible to activate a user account with a token that is not
      * intended for this user.
@@ -26,5 +26,8 @@ class UserActivationToken(
     /**
      * The time when the token expires. After this time, the token is no longer valid.
      */
-    val expiresAt: Instant
+    val expiresAt: Instant,
+    override val id: String? = null,
+    override val version: Int? = null,
+    override val createdAt: Instant? = null,
 ) : AbstractEntity()

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/workspaces/SavedWorkspaceAccessToken.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/workspaces/SavedWorkspaceAccessToken.kt
@@ -2,9 +2,13 @@ package io.orangebuffalo.simpleaccounting.business.workspaces
 
 import io.orangebuffalo.simpleaccounting.business.common.pesistence.AbstractEntity
 import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
 
 @Table
-class SavedWorkspaceAccessToken(
-    var workspaceAccessTokenId: String,
-    var ownerId: String
+data class SavedWorkspaceAccessToken(
+    val workspaceAccessTokenId: String,
+    val ownerId: String,
+    override val id: String? = null,
+    override val version: Int? = null,
+    override val createdAt: Instant? = null,
 ) : AbstractEntity()

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/workspaces/Workspace.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/workspaces/Workspace.kt
@@ -2,10 +2,14 @@ package io.orangebuffalo.simpleaccounting.business.workspaces
 
 import io.orangebuffalo.simpleaccounting.business.common.pesistence.AbstractEntity
 import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
 
 @Table
-class Workspace(
-    var name: String,
+data class Workspace(
+    val name: String,
     val ownerId: String,
-    val defaultCurrency: String
+    val defaultCurrency: String,
+    override val id: String? = null,
+    override val version: Int? = null,
+    override val createdAt: Instant? = null,
 ) : AbstractEntity()

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/workspaces/WorkspaceAccessToken.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/workspaces/WorkspaceAccessToken.kt
@@ -5,10 +5,13 @@ import org.springframework.data.relational.core.mapping.Table
 import java.time.Instant
 
 @Table
-class WorkspaceAccessToken(
-    var workspaceId: String,
+data class WorkspaceAccessToken(
+    val workspaceId: String,
     val timeCreated: Instant,
     val validTill: Instant,
     val revoked: Boolean,
-    val token: String
+    val token: String,
+    override val id: String? = null,
+    override val version: Int? = null,
+    override val createdAt: Instant? = null,
 ) : AbstractEntity()

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/oauth2/impl/DbReactiveOAuth2AuthorizedClientService.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/oauth2/impl/DbReactiveOAuth2AuthorizedClientService.kt
@@ -83,15 +83,16 @@ class DbReactiveOAuth2AuthorizedClientService(
                     )
                 )
             } else {
-                existingClient.accessToken = accessToken.tokenValue
-                existingClient.accessTokenExpiresAt = accessToken.expiresAt
-                existingClient.accessTokenIssuedAt = accessToken.issuedAt
-                existingClient.accessTokenScopes = accessToken.scopes.map { ClientTokenScope(it) }.toSet()
-                if (refreshToken != null) {
-                    existingClient.refreshToken = refreshToken.tokenValue
-                    existingClient.refreshTokenIssuedAt = refreshToken.issuedAt
-                }
-                authorizedClientRepository.save(existingClient)
+                authorizedClientRepository.save(
+                    existingClient.copy(
+                        accessToken = accessToken.tokenValue,
+                        accessTokenExpiresAt = accessToken.expiresAt,
+                        accessTokenIssuedAt = accessToken.issuedAt,
+                        accessTokenScopes = accessToken.scopes.map { ClientTokenScope(it) }.toSet(),
+                        refreshToken = refreshToken?.tokenValue ?: existingClient.refreshToken,
+                        refreshTokenIssuedAt = refreshToken?.issuedAt ?: existingClient.refreshTokenIssuedAt,
+                    )
+                )
             }
         }
     }

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/oauth2/impl/PersistentOAuth2AuthorizedClient.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/oauth2/impl/PersistentOAuth2AuthorizedClient.kt
@@ -7,18 +7,21 @@ import org.springframework.data.relational.core.mapping.Table
 import java.time.Instant
 
 @Table("PERSISTENT_OAUTH2_AUTHORIZED_CLIENT")
-class PersistentOAuth2AuthorizedClient(
+data class PersistentOAuth2AuthorizedClient(
     val clientRegistrationId: String,
     val userName: String,
-    var accessToken: String,
-    var accessTokenIssuedAt: Instant?,
-    var accessTokenExpiresAt: Instant?,
+    val accessToken: String,
+    val accessTokenIssuedAt: Instant?,
+    val accessTokenExpiresAt: Instant?,
 
     @field:MappedCollection(idColumn = "CLIENT_ID")
-    var accessTokenScopes: Set<ClientTokenScope>,
+    val accessTokenScopes: Set<ClientTokenScope>,
 
-    var refreshToken: String?,
-    var refreshTokenIssuedAt: Instant?
+    val refreshToken: String?,
+    val refreshTokenIssuedAt: Instant?,
+    override val id: String? = null,
+    override val version: Int? = null,
+    override val createdAt: Instant? = null,
 
 ) : AbstractEntity()
 

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/persistence/CreatedAtPopulatingCallback.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/persistence/CreatedAtPopulatingCallback.kt
@@ -7,13 +7,13 @@ import org.springframework.stereotype.Component
 
 @Component
 class CreatedAtPopulatingCallback(
-    private val timeService: TimeService
+    private val timeService: TimeService,
+    private val entityPropertyUpdater: EntityPropertyUpdater,
 ) : BeforeConvertCallback<AbstractEntity> {
 
     override fun onBeforeConvert(entity: AbstractEntity): AbstractEntity {
-        if (entity.version == null && entity.createdAt == null) {
-            entity.createdAt = timeService.currentTime()
-        }
-        return entity
+        return if (entity.version == null && entity.createdAt == null) {
+            entityPropertyUpdater.update(entity, AbstractEntity::createdAt.name, timeService.currentTime())
+        } else entity
     }
 }

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/persistence/EntityPropertyUpdater.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/persistence/EntityPropertyUpdater.kt
@@ -1,0 +1,20 @@
+package io.orangebuffalo.simpleaccounting.infra.persistence
+
+import org.springframework.data.jdbc.core.mapping.JdbcMappingContext
+import org.springframework.stereotype.Component
+
+@Component
+class EntityPropertyUpdater(
+    private val jdbcMappingContext: JdbcMappingContext,
+) {
+
+    fun <T : Any> update(entity: T, propertyName: String, value: Any?): T {
+        val persistentEntity = jdbcMappingContext.getRequiredPersistentEntity(entity.javaClass)
+        val property = persistentEntity.getRequiredPersistentProperty(propertyName)
+        val accessor = persistentEntity.getPropertyAccessor(entity)
+        accessor.setProperty(property, value)
+
+        @Suppress("UNCHECKED_CAST")
+        return accessor.bean as T
+    }
+}

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/persistence/IdPopulatingCallback.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/persistence/IdPopulatingCallback.kt
@@ -10,12 +10,12 @@ private const val ENTITY_ID_LENGTH = 10
 @Component
 class IdPopulatingCallback(
     private val tokenGenerator: TokenGenerator,
+    private val entityPropertyUpdater: EntityPropertyUpdater,
 ) : BeforeConvertCallback<AbstractEntity> {
 
     override fun onBeforeConvert(entity: AbstractEntity): AbstractEntity {
-        if (entity.id == null) {
-            entity.id = tokenGenerator.generateToken(ENTITY_ID_LENGTH)
-        }
-        return entity
+        return if (entity.id == null) {
+            entityPropertyUpdater.update(entity, AbstractEntity::id.name, tokenGenerator.generateToken(ENTITY_ID_LENGTH))
+        } else entity
     }
 }

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/common/pesistence/AbstractEntityTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/common/pesistence/AbstractEntityTest.kt
@@ -3,6 +3,7 @@ package io.orangebuffalo.simpleaccounting.business.common.pesistence
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.Test
+import java.time.Instant
 
 internal class AbstractEntityTest {
 
@@ -12,36 +13,33 @@ internal class AbstractEntityTest {
     }
 
     @Test
-    fun `hashcode should not be changed after ID assignment`() {
+    fun `copy with assigned ID should be equal to persisted entity`() {
         val testEntity = TestEntity()
-        val initialHashcode = testEntity.hashCode()
 
-        testEntity.id = "42"
+        val persistedEntity = testEntity.copy(id = "42")
 
-        testEntity.hashCode().shouldBe(initialHashcode)
+        persistedEntity.shouldBe(TestEntity(id = "42"))
     }
 
     @Test
     fun `two objects with the same ID should be equal`() {
-        val firstEntity = TestEntity()
-        firstEntity.id = "42"
-
-        val secondEntity = TestEntity()
-        secondEntity.id = "42"
+        val firstEntity = TestEntity(id = "42")
+        val secondEntity = TestEntity(id = "42")
 
         firstEntity.shouldBe(secondEntity)
     }
 
     @Test
     fun `two entities with the same ID should have the same hashcode`() {
-        val firstEntity = TestEntity()
-        firstEntity.id = "42"
-
-        val secondEntity = TestEntity()
-        secondEntity.id = "42"
+        val firstEntity = TestEntity(id = "42")
+        val secondEntity = TestEntity(id = "42")
 
         firstEntity.hashCode().shouldBe(secondEntity.hashCode())
     }
 }
 
-internal class TestEntity : AbstractEntity()
+internal data class TestEntity(
+    override val id: String? = null,
+    override val version: Int? = null,
+    override val createdAt: Instant? = null,
+) : AbstractEntity()

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/security/authentication/BruteForceDefenseTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/security/authentication/BruteForceDefenseTest.kt
@@ -315,14 +315,29 @@ class BruteForceDefenseTest(
         }
     }
 
-    private fun setupFryLoginStatistics(spec: LoginStatistics.() -> Unit) {
+    private fun setupFryLoginStatistics(spec: MutableLoginStatistics.() -> Unit) {
         transactionTemplate.execute {
             val fry = platformUsersRepository.findByUserName("Fry")
                 ?: throw IllegalStateException("Fry is not found?!")
-            fry.loginStatistics.spec()
-            platformUsersRepository.save(fry)
+            val loginStatistics = MutableLoginStatistics(
+                failedAttemptsCount = fry.loginStatistics.failedAttemptsCount,
+                temporaryLockExpirationTime = fry.loginStatistics.temporaryLockExpirationTime,
+            ).apply(spec)
+            platformUsersRepository.save(
+                fry.copy(
+                    loginStatistics = LoginStatistics(
+                        failedAttemptsCount = loginStatistics.failedAttemptsCount,
+                        temporaryLockExpirationTime = loginStatistics.temporaryLockExpirationTime,
+                    )
+                )
+            )
         }
     }
+
+    private data class MutableLoginStatistics(
+        var failedAttemptsCount: Int,
+        var temporaryLockExpirationTime: Instant?,
+    )
 
     private fun MutationProjection.loginMutation(): MutationProjection =
         createAccessTokenByCredentials(password = "qwerty", userName = "Fry") { accessToken }

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/shared/login/LoginFullStackTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/shared/login/LoginFullStackTest.kt
@@ -258,11 +258,26 @@ class LoginFullStackTest : SaFullStackTestBase() {
         fry.loginStatistics.spec()
     }
 
-    private fun setupFryLoginStatistics(spec: LoginStatistics.() -> Unit) {
+    private fun setupFryLoginStatistics(spec: MutableLoginStatistics.() -> Unit) {
         val fry = aggregateTemplate.findById<PlatformUser>(preconditions.fry.id!!)!!
-        fry.loginStatistics.spec()
-        aggregateTemplate.save(fry)
+        val loginStatistics = MutableLoginStatistics(
+            failedAttemptsCount = fry.loginStatistics.failedAttemptsCount,
+            temporaryLockExpirationTime = fry.loginStatistics.temporaryLockExpirationTime,
+        ).apply(spec)
+        aggregateTemplate.save(
+            fry.copy(
+                loginStatistics = LoginStatistics(
+                    failedAttemptsCount = loginStatistics.failedAttemptsCount,
+                    temporaryLockExpirationTime = loginStatistics.temporaryLockExpirationTime,
+                )
+            )
+        )
     }
+
+    private data class MutableLoginStatistics(
+        var failedAttemptsCount: Int,
+        var temporaryLockExpirationTime: Instant?,
+    )
 
     private val preconditions by lazyPreconditions {
         object {

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/tests/infra/database/EntitiesFactory.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/tests/infra/database/EntitiesFactory.kt
@@ -57,8 +57,9 @@ class EntitiesFactory(private val infra: EntitiesFactoryInfra) {
         isAdmin = isAdmin,
         documentsStorage = documentsStorage,
         i18nSettings = i18nSettings,
-        activated = activated
-    ).also { it.createdAt = createdAt }.save()
+        activated = activated,
+        createdAt = createdAt,
+    ).save()
 
     fun userActivationToken(
         user: PlatformUser? = null,
@@ -131,8 +132,9 @@ class EntitiesFactory(private val infra: EntitiesFactoryInfra) {
         return Workspace(
             name = name,
             ownerId = ownerId!!,
-            defaultCurrency = defaultCurrency
-        ).also { it.createdAt = createdAt }.save()
+            defaultCurrency = defaultCurrency,
+            createdAt = createdAt,
+        ).save()
     }
 
     fun workspaceAccessToken(
@@ -149,8 +151,9 @@ class EntitiesFactory(private val infra: EntitiesFactoryInfra) {
             timeCreated = timeCreated,
             validTill = validTill,
             revoked = revoked,
-            token = token
-        ).also { it.createdAt = createdAt }.save()
+            token = token,
+            createdAt = createdAt,
+        ).save()
     }
 
     fun document(
@@ -171,8 +174,9 @@ class EntitiesFactory(private val infra: EntitiesFactoryInfra) {
             storageLocation = storageLocation,
             timeUploaded = timeUploaded,
             sizeInBytes = sizeInBytes,
-            mimeType = mimeType
-        ).also { it.createdAt = createdAt }.save()
+            mimeType = mimeType,
+            createdAt = createdAt,
+        ).save()
     }
 
     fun category(
@@ -189,8 +193,9 @@ class EntitiesFactory(private val infra: EntitiesFactoryInfra) {
             workspaceId = workspaceId!!,
             income = income,
             expense = expense,
-            description = description
-        ).also { it.createdAt = createdAt }.save()
+            description = description,
+            createdAt = createdAt,
+        ).save()
     }
 
     fun generalTax(
@@ -205,8 +210,9 @@ class EntitiesFactory(private val infra: EntitiesFactoryInfra) {
             title = title,
             workspaceId = workspaceId!!,
             rateInBps = rateInBps,
-            description = description
-        ).also { it.createdAt = createdAt }.save()
+            description = description,
+            createdAt = createdAt,
+        ).save()
     }
 
     fun expense(
@@ -245,8 +251,9 @@ class EntitiesFactory(private val infra: EntitiesFactoryInfra) {
             generalTaxAmount = generalTaxAmount,
             generalTaxRateInBps = generalTaxRateInBps,
             notes = notes,
-            status = status
-        ).also { it.createdAt = createdAt }.save()
+            status = status,
+            createdAt = createdAt,
+        ).save()
     }
 
     fun amountsInDefaultCurrency(
@@ -294,8 +301,9 @@ class EntitiesFactory(private val infra: EntitiesFactoryInfra) {
             dateReceived = dateReceived,
             originalAmount = originalAmount,
             title = title,
-            linkedInvoiceId = linkedInvoice?.id
-        ).also { it.createdAt = createdAt }.save()
+            linkedInvoiceId = linkedInvoice?.id,
+            createdAt = createdAt,
+        ).save()
     }
 
     fun customer(
@@ -307,7 +315,8 @@ class EntitiesFactory(private val infra: EntitiesFactoryInfra) {
         return Customer(
             name = name,
             workspaceId = workspaceId!!,
-        ).also { it.createdAt = createdAt }.save()
+            createdAt = createdAt,
+        ).save()
     }
 
     fun invoice(
@@ -342,8 +351,9 @@ class EntitiesFactory(private val infra: EntitiesFactoryInfra) {
             }.toSet(),
             notes = notes,
             generalTaxId = generalTax?.id,
-            status = status
-        ).also { it.createdAt = createdAt }.save()
+            status = status,
+            createdAt = createdAt,
+        ).save()
     }
 
     fun incomeTaxPayment(
@@ -364,8 +374,9 @@ class EntitiesFactory(private val infra: EntitiesFactoryInfra) {
             amount = amount,
             title = title,
             attachments = attachments.asSequence().map { IncomeTaxPaymentAttachment(it.id!!) }.toSet(),
-            notes = notes
-        ).also { it.createdAt = createdAt }.save()
+            notes = notes,
+            createdAt = createdAt,
+        ).save()
     }
 
     fun <T : Any> save(vararg entities: T) = entities.forEach { infra.save(it) }


### PR DESCRIPTION
## Summary
- Migrates domain entities from mutable POJOs to immutable Kotlin data classes.
- Replaces in-place entity mutation with copy-based update flows across GraphQL mutations, services, auth, OAuth, and Google Drive integration.
- Adds persistence support for immutable metadata population through Spring Data property accessors.

## Why
- Enables safer domain updates through explicit immutable copies.
- Preserves centralized entity identity behavior and persistence metadata handling while avoiding mutable entity state.

## Testing
- `./gradlew :app:compileKotlin :app:compileTestKotlin --console=plain`
- `./gradlew :app:test --tests "io.orangebuffalo.simpleaccounting.business.common.pesistence.*" --console=plain`
- `./gradlew :app:check --console=plain`
- `./gradlew assemble check --console=plain`