### PR TITLE
feat: Add typed SA configuration properties

### DIFF
--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/gdrive/GoogleDriveDocumentsStorageProperties.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/gdrive/GoogleDriveDocumentsStorageProperties.kt
@@ -1,0 +1,26 @@
+package io.orangebuffalo.simpleaccounting.business.documents.storage.gdrive
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+/**
+ * Google Drive document storage configuration.
+ */
+@ConfigurationProperties("sa.documents.storage.google-drive")
+@Component
+data class GoogleDriveDocumentsStorageProperties(
+    /**
+     * Base URL of the Google Drive API.
+     */
+    var baseApiUrl: String = "https://www.googleapis.com",
+
+    /**
+     * OAuth client id for Google Drive integration.
+     */
+    var clientId: String = "",
+
+    /**
+     * OAuth client secret for Google Drive integration.
+     */
+    var clientSecret: String = "",
+)

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/gdrive/impl/GoogleDriveApiAdapter.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/gdrive/impl/GoogleDriveApiAdapter.kt
@@ -2,13 +2,13 @@ package io.orangebuffalo.simpleaccounting.business.documents.storage.gdrive.impl
 
 import io.orangebuffalo.simpleaccounting.business.documents.storage.DocumentStorageException
 import io.orangebuffalo.simpleaccounting.business.documents.storage.StorageAuthorizationRequiredException
+import io.orangebuffalo.simpleaccounting.business.documents.storage.gdrive.GoogleDriveDocumentsStorageProperties
 import io.orangebuffalo.simpleaccounting.business.documents.storage.gdrive.OAUTH2_CLIENT_REGISTRATION_ID
 import io.orangebuffalo.simpleaccounting.infra.oauth2.OAuth2WebClientBuilderProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactive.awaitSingle
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.core.io.buffer.DataBuffer
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -26,7 +26,7 @@ private val log = mu.KotlinLogging.logger {}
 @Component
 class GoogleDriveApiAdapter(
     private val webClientBuilderProvider: OAuth2WebClientBuilderProvider,
-    @Value("\${sa.documents.storage.google-drive.base-api-url}") private val baseApiUrl: String
+    private val googleDriveDocumentsStorageProperties: GoogleDriveDocumentsStorageProperties,
 ) {
 
     suspend fun uploadFile(
@@ -165,7 +165,7 @@ class GoogleDriveApiAdapter(
 
     private fun createWebClient() = webClientBuilderProvider
         .forClient(OAUTH2_CLIENT_REGISTRATION_ID)
-        .baseUrl(baseApiUrl)
+        .baseUrl(googleDriveDocumentsStorageProperties.baseApiUrl)
         .build()
 
     private suspend inline fun WebClient.RequestHeadersSpec<*>.executeDriveRequest(

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/local/LocalFileSystemDocumentsStorageProperties.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/local/LocalFileSystemDocumentsStorageProperties.kt
@@ -4,11 +4,20 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.stereotype.Component
 import java.nio.file.Path
 
+/**
+ * Local filesystem document storage configuration.
+ */
 @ConfigurationProperties(prefix = "sa.documents.storage.local-fs")
 @Component
 class LocalFileSystemDocumentsStorageProperties {
 
+    /**
+     * Whether local filesystem document storage is enabled.
+     */
     var enabled: Boolean = false
 
+    /**
+     * Directory where documents are stored on the local filesystem.
+     */
     lateinit var baseDirectory: Path
 }

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/DatabaseProperties.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/DatabaseProperties.kt
@@ -1,0 +1,21 @@
+package io.orangebuffalo.simpleaccounting.infra
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+/**
+ * Database credentials used by the application datasource configuration.
+ */
+@ConfigurationProperties("sa.database")
+@Component
+data class DatabaseProperties(
+    /**
+     * Database user name.
+     */
+    var username: String = "sa",
+
+    /**
+     * Database user password.
+     */
+    var password: String = "",
+)

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/SimpleAccountingProperties.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/SimpleAccountingProperties.kt
@@ -3,8 +3,14 @@ package io.orangebuffalo.simpleaccounting.infra
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.stereotype.Component
 
+/**
+ * Root Simple Accounting application configuration.
+ */
 @ConfigurationProperties("sa")
 @Component
 data class SimpleAccountingProperties(
+    /**
+     * Public URL used by clients to access the application.
+     */
     var publicUrl: String = "",
 )

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/backups/BackupProperties.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/backups/BackupProperties.kt
@@ -3,18 +3,60 @@ package io.orangebuffalo.simpleaccounting.infra.backups
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.stereotype.Component
 
+/**
+ * System data backup configuration.
+ */
 @ConfigurationProperties("sa.backup")
 @Component
 data class BackupProperties(
+    /**
+     * Whether scheduled system data backups are enabled.
+     */
     var enabled: Boolean = false,
+
+    /**
+     * Delay between scheduled backup attempts, in hours.
+     */
+    var schedulingDelayInHours: Long = 12,
+
+    /**
+     * Maximum number of backup files to retain in the remote backup storage.
+     */
     var maxBackups: Int = 50,
+
+    /**
+     * Dropbox backup provider configuration.
+     */
     var dropbox: DropboxBackupProperties = DropboxBackupProperties(),
 ) {
 
+    /**
+     * Dropbox backup provider configuration.
+     */
     data class DropboxBackupProperties(
+        /**
+         * Whether Dropbox should be used as the backup provider.
+         */
+        var active: Boolean = false,
+
+        /**
+         * Dropbox OAuth access token.
+         */
         var accessToken: String? = null,
+
+        /**
+         * Dropbox OAuth refresh token.
+         */
         var refreshToken: String? = null,
+
+        /**
+         * Dropbox OAuth client id.
+         */
         var clientId: String? = null,
+
+        /**
+         * Dropbox OAuth client secret.
+         */
         var clientSecret: String? = null,
     )
 }

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/backups/SystemDataBackupService.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/backups/SystemDataBackupService.kt
@@ -26,7 +26,7 @@ class SystemDataBackupService(
     private val backupProperties: BackupProperties,
 ) {
 
-    @Scheduled(fixedDelayString = "\${sa.backup.scheduling-delay-in-hours}", timeUnit = TimeUnit.HOURS)
+    @Scheduled(fixedDelayString = "#{@backupProperties.schedulingDelayInHours}", timeUnit = TimeUnit.HOURS)
     fun executeBackup() = runBlocking {
         if (!backupProperties.enabled) {
             logger.info { "Backup is disabled" }

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/data/DemoProperties.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/data/DemoProperties.kt
@@ -1,0 +1,16 @@
+package io.orangebuffalo.simpleaccounting.infra.data
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+/**
+ * Demo data generation configuration.
+ */
+@ConfigurationProperties("sa.demo")
+@Component
+data class DemoProperties(
+    /**
+     * Whether demo data should be generated during application startup.
+     */
+    var enabled: Boolean = false,
+)


### PR DESCRIPTION
## Summary
- Added typed configuration properties for SA database, demo, backup, and document storage settings.
- Replaced direct Google Drive `@Value` configuration access with typed properties.
- Documented SA configuration properties with KDoc.

## Why
Typed properties make SA configuration easier to discover and safer to use from application code while keeping configuration documentation close to the owning classes.

## Testing
- `./gradlew :app:compileKotlin :app:compileTestKotlin --console=plain`