### PR TITLE
feat: Add unused document deletion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,9 @@ cd frontend && bun run lint
 
 # GraphQL schema generation
 ./gradlew :app:updateGraphqlSchema
+
+# Frontend GraphQL type generation
+cd frontend && bun run graphql-codegen
 ```
 
 ### Development Commands
@@ -95,7 +98,7 @@ After making changes, choose validation based on the assessed blast radius:
    ./gradlew assemble check --console=plain
    ```
 For GraphQL changes, regenerate committed artifacts as needed before validation:
-- Endpoint/schema changes require schema and frontend TypeScript type regeneration.
+- Endpoint/schema changes always require both schema and frontend TypeScript type regeneration.
 - Frontend query or mutation changes require frontend TypeScript type regeneration.
 - See the GraphQL API Development section for the exact commands.
 
@@ -104,8 +107,9 @@ For GraphQL changes, regenerate committed artifacts as needed before validation:
 **Code-first GraphQL** with schema generation:
 - After GraphQL changes, run: `./gradlew :app:updateGraphqlSchema`
 - Regenerates `app/src/test/resources/api-schema.graphqls`
+- After every GraphQL API change, also run: `cd frontend && bun run graphql-codegen`
 - Frontend TypeScript types are committed to `frontend/src/services/api/gql/` and verified by the `verifyGqlTypes` Gradle task (part of `check`)
-- To regenerate frontend TypeScript types during development, run: `cd frontend && bun run graphql-codegen`
+- Always commit regenerated frontend GraphQL types when the schema or frontend GraphQL operations change.
 
 ## File Locations
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -208,6 +208,11 @@ tasks.register<Test>("updateGraphqlSchema") {
     group = "verification"
     description = "Updates the Git-managed GraphQL schema by running GraphqlSchemaTest with override enabled."
 
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    inputs.files(sourceSets.main.get().allSource)
+    inputs.files(sourceSets.test.get().allSource)
+
     filter {
         includeTestsMatching("*GraphqlSchemaTest*")
     }

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/documents/DeleteDocumentMutation.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/documents/DeleteDocumentMutation.kt
@@ -1,0 +1,35 @@
+package io.orangebuffalo.simpleaccounting.business.api.documents
+
+import com.expediagroup.graphql.generator.annotations.GraphQLDescription
+import com.expediagroup.graphql.server.operations.Mutation
+import io.orangebuffalo.simpleaccounting.business.api.directives.RequiredAuth
+import io.orangebuffalo.simpleaccounting.business.api.errors.BusinessError
+import io.orangebuffalo.simpleaccounting.business.documents.DocumentIsUsedException
+import io.orangebuffalo.simpleaccounting.business.documents.DocumentsService
+import org.springframework.stereotype.Component
+import org.springframework.validation.annotation.Validated
+
+@Component
+@Validated
+class DeleteDocumentMutation(
+    private val documentsService: DocumentsService,
+) : Mutation {
+
+    @Suppress("unused")
+    @GraphQLDescription("Deletes an unused document from the database and the backing document storage.")
+    @RequiredAuth(RequiredAuth.AuthType.REGULAR_USER)
+    @BusinessError(
+        exceptionClass = DocumentIsUsedException::class,
+        errorCode = "DOCUMENT_IS_USED",
+        errorCodeDescription = "The document is attached to another entity and cannot be deleted.",
+    )
+    suspend fun deleteDocument(
+        @GraphQLDescription("ID of the workspace the document belongs to.")
+        workspaceId: String,
+        @GraphQLDescription("ID of the document to delete.")
+        documentId: String,
+    ): Boolean {
+        documentsService.deleteDocument(workspaceId, documentId)
+        return true
+    }
+}

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/DocumentsService.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/DocumentsService.kt
@@ -116,6 +116,27 @@ class DocumentsService(
         }
     }
 
+    suspend fun deleteDocument(workspaceId: String, documentId: String) {
+        val workspace = workspacesService.getAccessibleWorkspace(workspaceId, WorkspaceAccessMode.READ_WRITE)
+        val document = getDocumentByIdAndWorkspaceId(documentId, workspaceId)
+            ?: throw EntityNotFoundException("Document $documentId is not found")
+
+        val documentUsages = withDbContext {
+            documentRepository.findUsagesByDocumentIds(listOf(documentId))[documentId].orEmpty()
+        }
+        if (documentUsages.isNotEmpty()) {
+            throw DocumentIsUsedException(documentId)
+        }
+
+        getDocumentStorageById(document.storageId).deleteDocument(
+            workspace,
+            document.storageLocation ?: throw IllegalStateException("$document has not location assigned")
+        )
+        withDbContext {
+            documentRepository.delete(document)
+        }
+    }
+
     suspend fun getUploadToken(workspaceId: String): String {
         workspacesService.validateWorkspaceAccess(workspaceId, WorkspaceAccessMode.READ_WRITE)
         val userName = getCurrentPrincipal().userName
@@ -187,3 +208,5 @@ data class PersistentUploadRequest(
     val workspaceId: String,
     val userName: String,
 )
+
+class DocumentIsUsedException(documentId: String) : RuntimeException("Document $documentId is used and cannot be deleted")

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/DocumentsStorage.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/DocumentsStorage.kt
@@ -13,6 +13,8 @@ interface DocumentsStorage {
 
     suspend fun getDocumentContent(workspace: Workspace, storageLocation: String): Flow<DataBuffer>
 
+    suspend fun deleteDocument(workspace: Workspace, storageLocation: String)
+
     suspend fun getCurrentUserStorageStatus(): DocumentsStorageStatus
 
     suspend fun isDownloadAvailableForUser(userId: String): Boolean

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/gdrive/GoogleDriveDocumentsStorage.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/gdrive/GoogleDriveDocumentsStorage.kt
@@ -88,6 +88,10 @@ class GoogleDriveDocumentsStorage(
     override suspend fun getDocumentContent(workspace: Workspace, storageLocation: String): Flow<DataBuffer> =
         googleDriveApi.downloadFile(storageLocation)
 
+    override suspend fun deleteDocument(workspace: Workspace, storageLocation: String) {
+        googleDriveApi.deleteFile(storageLocation)
+    }
+
     override suspend fun getCurrentUserStorageStatus(): DocumentsStorageStatus {
         val integrationStatus = getCurrentUserIntegrationStatus()
         return DocumentsStorageStatus(

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/gdrive/impl/GoogleDriveApiAdapter.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/gdrive/impl/GoogleDriveApiAdapter.kt
@@ -84,6 +84,18 @@ class GoogleDriveApiAdapter(
             .asFlow()
     }
 
+    suspend fun deleteFile(fileId: String) {
+        createWebClient()
+            .delete()
+            .uri { builder ->
+                builder.path("/drive/v3/files/$fileId")
+                    .build()
+            }
+            .executeDriveRequest(setOf(HttpStatus.OK, HttpStatus.NO_CONTENT)) { errorJson ->
+                "Error while deleting $fileId: $errorJson"
+            }
+    }
+
     suspend fun findFolderByNameAndParent(
         folderName: String,
         parentFolderId: String
@@ -169,6 +181,7 @@ class GoogleDriveApiAdapter(
         .build()
 
     private suspend inline fun WebClient.RequestHeadersSpec<*>.executeDriveRequest(
+        successStatuses: Set<HttpStatus> = setOf(HttpStatus.OK),
         errorDescriptor: (errorJson: String?) -> String
     ): ClientResponse {
         log.debug { "Executing request: $this" }
@@ -185,7 +198,7 @@ class GoogleDriveApiAdapter(
         if (statusCode == HttpStatus.UNAUTHORIZED || statusCode == HttpStatus.FORBIDDEN) {
             log.debug { "Authorization required: $statusCode" }
             throw StorageAuthorizationRequiredException(message = "Not authorized: $statusCode")
-        } else if (statusCode != HttpStatus.OK) {
+        } else if (statusCode !in successStatuses) {
             val errorJson = clientResponse.bodyToMono(String::class.java).awaitFirstOrNull()
             log.debug { "Error response with code $statusCode: $errorJson" }
             if (statusCode == HttpStatus.NOT_FOUND) {

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/local/LocalFileSystemDocumentsStorage.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/local/LocalFileSystemDocumentsStorage.kt
@@ -45,6 +45,12 @@ class LocalFileSystemDocumentsStorage(
         ).asFlow()
     }
 
+    override suspend fun deleteDocument(workspace: Workspace, storageLocation: String) {
+        withContext(localFsStorageContext) {
+            File(config.baseDirectory.toFile(), storageLocation).delete()
+        }
+    }
+
     override suspend fun getCurrentUserStorageStatus() = DocumentsStorageStatus(true)
 
     override suspend fun isDownloadAvailableForUser(userId: String) = true

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/noop/NoopDocumentsStorage.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/storage/noop/NoopDocumentsStorage.kt
@@ -57,6 +57,9 @@ class NoopDocumentsStorage : DocumentsStorage {
             }
     }
 
+    override suspend fun deleteDocument(workspace: Workspace, storageLocation: String) {
+    }
+
     override suspend fun getCurrentUserStorageStatus() = DocumentsStorageStatus(true)
 
     override suspend fun isDownloadAvailableForUser(userId: String) = true

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/documents/DeleteDocumentMutationTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/documents/DeleteDocumentMutationTest.kt
@@ -1,0 +1,179 @@
+package io.orangebuffalo.simpleaccounting.business.api.documents
+
+import io.kotest.matchers.shouldBe
+import io.orangebuffalo.simpleaccounting.SaIntegrationTestBase
+import io.orangebuffalo.simpleaccounting.business.documents.Document
+import io.orangebuffalo.simpleaccounting.tests.infra.api.ApiTestClient
+import io.orangebuffalo.simpleaccounting.tests.infra.api.GraphqlClientRequestExecutor
+import io.orangebuffalo.simpleaccounting.tests.infra.api.graphqlRawQuery
+import io.orangebuffalo.simpleaccounting.tests.infra.ui.TestDocumentsStorage
+import io.orangebuffalo.simpleaccounting.tests.infra.utils.MOCK_TIME
+import io.orangebuffalo.simpleaccounting.tests.infra.utils.findSingle
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+private const val DELETE_DOCUMENT_MUTATION = "deleteDocument"
+
+@DisplayName("deleteDocument mutation")
+class DeleteDocumentMutationTest(
+    @Autowired private val client: ApiTestClient,
+    @Autowired private val testDocumentsStorage: TestDocumentsStorage,
+) : SaIntegrationTestBase() {
+
+    private val preconditions by lazyPreconditions {
+        object {
+            val fry = fry()
+            val farnsworth = farnsworth()
+            val zoidberg = zoidberg()
+            val fryWorkspace = workspace(owner = fry)
+            val zoidbergWorkspace = workspace(owner = zoidberg)
+            val workspaceAccessToken = workspaceAccessToken(
+                workspace = fryWorkspace,
+                validTill = MOCK_TIME.plusSeconds(10000),
+            )
+            val deliveryReceipt = document(
+                workspace = fryWorkspace,
+                name = "Delivery to Mars receipt",
+                storageLocation = "delivery-to-mars-receipt",
+            )
+            val zoidbergReceipt = document(
+                workspace = zoidbergWorkspace,
+                name = "Zoidberg receipt",
+                storageLocation = "zoidberg-receipt",
+            )
+        }
+    }
+
+    @Nested
+    @DisplayName("Authorization")
+    inner class Authorization {
+
+        @Test
+        fun `should return NOT_AUTHORIZED error for anonymous requests`() {
+            client
+                .deleteDocumentMutation(
+                    workspaceId = preconditions.fryWorkspace.id!!,
+                    documentId = preconditions.deliveryReceipt.id!!,
+                )
+                .fromAnonymous()
+                .executeAndVerifyNotAuthorized(path = DELETE_DOCUMENT_MUTATION)
+        }
+
+        @Test
+        fun `should return NOT_AUTHORIZED error for workspace access token`() {
+            client
+                .deleteDocumentMutation(
+                    workspaceId = preconditions.fryWorkspace.id!!,
+                    documentId = preconditions.deliveryReceipt.id!!,
+                )
+                .usingSharedWorkspaceToken(preconditions.workspaceAccessToken.token)
+                .executeAndVerifyNotAuthorized(path = DELETE_DOCUMENT_MUTATION)
+        }
+    }
+
+    @Nested
+    @DisplayName("Business Flow")
+    inner class BusinessFlow {
+
+        @Test
+        fun `should delete unused document from database and storage`() {
+            val testData = preconditions {
+                object {
+                    val document = document(
+                        workspace = preconditions.fryWorkspace,
+                        name = "Slurm supplies receipt",
+                        storageLocation = "slurm-supplies-receipt",
+                    )
+                }
+            }
+            testDocumentsStorage.mockDocumentContent("slurm-supplies-receipt", "Slurm supplies".toByteArray())
+
+            client
+                .deleteDocumentMutation(
+                    workspaceId = preconditions.fryWorkspace.id!!,
+                    documentId = testData.document.id!!,
+                )
+                .from(preconditions.fry)
+                .executeAndVerifyResponse(
+                    DELETE_DOCUMENT_MUTATION to JsonPrimitive(true)
+                )
+
+            aggregateTemplate.findById(testData.document.id!!, Document::class.java).shouldBe(null)
+            testDocumentsStorage.hasUploadedContent("slurm-supplies-receipt").shouldBe(false)
+        }
+
+        @Test
+        fun `should return DOCUMENT_IS_USED error when document is attached`() {
+            val testData = preconditions {
+                object {
+                    val document = document(
+                        workspace = preconditions.fryWorkspace,
+                        name = "Planet Express equipment receipt",
+                        storageLocation = "planet-express-equipment-receipt",
+                    ).also { document ->
+                        expense(
+                            workspace = preconditions.fryWorkspace,
+                            title = "Planet Express equipment",
+                            attachments = setOf(document),
+                        )
+                    }
+                }
+            }
+            testDocumentsStorage.mockDocumentContent(
+                "planet-express-equipment-receipt",
+                "Planet Express equipment".toByteArray(),
+            )
+
+            client
+                .deleteDocumentMutation(
+                    workspaceId = preconditions.fryWorkspace.id!!,
+                    documentId = testData.document.id!!,
+                )
+                .from(preconditions.fry)
+                .executeAndVerifyBusinessError(
+                    message = "Document ${testData.document.id} is used and cannot be deleted",
+                    errorCode = "DOCUMENT_IS_USED",
+                    path = DELETE_DOCUMENT_MUTATION,
+                )
+
+            aggregateTemplate.findSingle<Document>(testData.document.id!!).id.shouldBe(testData.document.id)
+            testDocumentsStorage.hasUploadedContent("planet-express-equipment-receipt").shouldBe(true)
+        }
+
+        @Test
+        fun `should return ENTITY_NOT_FOUND error when workspace belongs to another user`() {
+            client
+                .deleteDocumentMutation(
+                    workspaceId = preconditions.zoidbergWorkspace.id!!,
+                    documentId = preconditions.zoidbergReceipt.id!!,
+                )
+                .from(preconditions.fry)
+                .executeAndVerifyEntityNotFoundError(path = DELETE_DOCUMENT_MUTATION)
+        }
+
+        @Test
+        fun `should return ENTITY_NOT_FOUND error when document belongs to another workspace`() {
+            client
+                .deleteDocumentMutation(
+                    workspaceId = preconditions.fryWorkspace.id!!,
+                    documentId = preconditions.zoidbergReceipt.id!!,
+                )
+                .from(preconditions.fry)
+                .executeAndVerifyEntityNotFoundError(path = DELETE_DOCUMENT_MUTATION)
+        }
+    }
+
+    private fun ApiTestClient.deleteDocumentMutation(
+        workspaceId: String,
+        documentId: String,
+    ): GraphqlClientRequestExecutor = graphqlRawQuery(
+        """
+            mutation {
+              deleteDocument(workspaceId: "$workspaceId", documentId: "$documentId")
+            }
+        """.trimIndent()
+    )
+}

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/tests/infra/ui/TestDocumentsStorage.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/tests/infra/ui/TestDocumentsStorage.kt
@@ -51,6 +51,10 @@ class TestDocumentsStorage : DocumentsStorage {
         return flowOf(DefaultDataBufferFactory.sharedInstance.wrap(content))
     }
 
+    override suspend fun deleteDocument(workspace: Workspace, storageLocation: String) {
+        uploadedDocuments.remove(storageLocation)
+    }
+
     fun mockDocumentContent(storageLocation: String, content: ByteArray) {
         uploadedDocuments[storageLocation] = content
     }
@@ -63,6 +67,8 @@ class TestDocumentsStorage : DocumentsStorage {
         return uploadedDocuments[storageLocation]
             ?: throw IllegalStateException("No content found for location: $storageLocation")
     }
+
+    fun hasUploadedContent(storageLocation: String): Boolean = uploadedDocuments.containsKey(storageLocation)
 
     fun reset() {
         uploadedDocuments.clear()

--- a/app/src/test/resources/api-schema.graphqls
+++ b/app/src/test/resources/api-schema.graphqls
@@ -824,6 +824,13 @@ type Mutation {
     "ID of the workspace to create the token for."
     workspaceId: String!
   ): WorkspaceAccessToken! @auth(type : REGULAR_USER)
+  "Deletes an unused document from the database and the backing document storage."
+  deleteDocument(
+    "ID of the document to delete."
+    documentId: String!,
+    "ID of the workspace the document belongs to."
+    workspaceId: String!
+  ): Boolean! @auth(type : REGULAR_USER) @businessError(errorCode : "DOCUMENT_IS_USED", errorCodeDescription : "The document is attached to another entity and cannot be deleted.")
   "Updates an existing category in the specified workspace."
   editCategory(
     "New description of the category."
@@ -1425,6 +1432,12 @@ enum CreateUserActivationTokenErrorCodes {
 enum CreateUserErrorCodes {
   "A user with the given username already exists."
   USER_ALREADY_EXISTS
+}
+
+"Possible business error codes for the deleteDocument operation."
+enum DeleteDocumentErrorCodes {
+  "The document is attached to another entity and cannot be deleted."
+  DOCUMENT_IS_USED
 }
 
 "Type of entity that uses a document."

--- a/frontend/src/services/api/gql/schema-types.ts
+++ b/frontend/src/services/api/gql/schema-types.ts
@@ -196,6 +196,12 @@ export type CustomersConnection = {
   totalCount: Scalars['Int']['output'];
 };
 
+/** Possible business error codes for the deleteDocument operation. */
+export enum DeleteDocumentErrorCodes {
+  /** The document is attached to another entity and cannot be deleted. */
+  DocumentIsUsed = 'DOCUMENT_IS_USED'
+}
+
 /** A document in a workspace. */
 export type Document = {
   __typename?: 'Document';
@@ -735,6 +741,8 @@ export type Mutation = {
   createWorkspace: Workspace;
   /** Creates a new access token for sharing workspace access. */
   createWorkspaceAccessToken: WorkspaceAccessToken;
+  /** Deletes an unused document from the database and the backing document storage. */
+  deleteDocument: Scalars['Boolean']['output'];
   /** Updates an existing category in the specified workspace. */
   editCategory: Category;
   /** Updates an existing customer in the specified workspace. */
@@ -915,6 +923,12 @@ export type MutationCreateWorkspaceArgs = {
 
 export type MutationCreateWorkspaceAccessTokenArgs = {
   validTill: Scalars['DateTime']['input'];
+  workspaceId: Scalars['String']['input'];
+};
+
+
+export type MutationDeleteDocumentArgs = {
+  documentId: Scalars['String']['input'];
   workspaceId: Scalars['String']['input'];
 };
 


### PR DESCRIPTION
## Summary
- Adds a `deleteDocument` GraphQL mutation for removing unused workspace documents.
- Deletes document records from the database and their content from the configured storage backend.
- Adds typed configuration property classes and fixes GraphQL schema generation inputs.

## Why
- Users can now clean up documents that are no longer attached to expenses, incomes, invoices, or income tax payments.
- Used documents are protected with a `DOCUMENT_IS_USED` business error to prevent broken references.
- Schema and frontend GraphQL types stay in sync after API changes.

## Testing
- `./gradlew :app:updateGraphqlSchema --console=plain`
- `cd frontend && bun run graphql-codegen`
- `./gradlew :app:test --tests "io.orangebuffalo.simpleaccounting.business.api.documents.DeleteDocumentMutationTest" --tests "io.orangebuffalo.simpleaccounting.infra.graphql.GraphqlSchemaTest" --console=plain`
- `cd frontend && bun run verify-gql-types`