### PR TITLE
fix: Run GraphQL data loaders on DB context

### DIFF
--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/CoroutinesSupport.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/CoroutinesSupport.kt
@@ -4,16 +4,21 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.reactor.ReactorContext
 import org.springframework.web.server.ServerWebExchange
 import reactor.util.context.Context
+import java.util.concurrent.CompletableFuture
 import kotlin.coroutines.coroutineContext
 
 @OptIn(DelicateCoroutinesApi::class)
 private val dbContext = newFixedThreadPoolContext(20, "db-context")
+private val dbContextExecutor = dbContext.asExecutor()
 
 suspend fun <T> withDbContext(block: suspend CoroutineScope.() -> T): T = withContext(dbContext, block)
 
 suspend fun <T> withDbContextAsync(block: suspend CoroutineScope.() -> T): Deferred<T> = coroutineScope {
     async(context = dbContext, block = block)
 }
+
+fun <T> supplyAsyncWithDbContext(block: () -> T): CompletableFuture<T> =
+    CompletableFuture.supplyAsync(block, dbContextExecutor)
 
 @Suppress("EXPERIMENTAL_API_USAGE")
 suspend fun getReactorContext(): Context {

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/graphql/GraphQlExtensions.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/graphql/GraphQlExtensions.kt
@@ -1,9 +1,9 @@
 package io.orangebuffalo.simpleaccounting.infra.graphql
 
 import com.expediagroup.graphql.dataloader.KotlinDataLoader
+import io.orangebuffalo.simpleaccounting.infra.supplyAsyncWithDbContext
 import org.dataloader.DataLoader
 import org.dataloader.DataLoaderFactory
-import java.util.concurrent.CompletableFuture
 
 /**
  * Creates a mapped [DataLoader] that executes the batch function asynchronously.
@@ -13,5 +13,5 @@ import java.util.concurrent.CompletableFuture
 fun <K : Any, V> newAsyncMappedDataLoader(
     batchLoader: (Set<K>) -> Map<K, V>,
 ): DataLoader<K, V> = DataLoaderFactory.newMappedDataLoader { keys ->
-    CompletableFuture.supplyAsync { batchLoader(keys) }
+    supplyAsyncWithDbContext { batchLoader(keys) }
 }


### PR DESCRIPTION
## Problem statement

A full-stack dashboard sanity check can flake when GraphQL data-loader batches run blocking JDBC repository calls on the JVM common pool and leave dashboard analytics requests pending.

## Solution summary

Run GraphQL data-loader batch work on the existing dedicated database coroutine context instead of the common pool.

## Notes

Verified with focused workspace-token and dashboard full-stack tests.