### PR TITLE
feat: add standalone documents API

### DIFF
--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/documents/DocumentUsageType.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/documents/DocumentUsageType.kt
@@ -17,4 +17,7 @@ enum class DocumentUsageType {
 
     @GraphQLDescription("Document is used by an income tax payment.")
     INCOME_TAX_PAYMENT,
+
+    @GraphQLDescription("Document is used by a standalone document.")
+    STANDALONE_DOCUMENT,
 }

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/CreateStandaloneDocumentMutation.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/CreateStandaloneDocumentMutation.kt
@@ -1,0 +1,38 @@
+package io.orangebuffalo.simpleaccounting.business.api.standalonedocuments
+
+import com.expediagroup.graphql.generator.annotations.GraphQLDescription
+import com.expediagroup.graphql.server.operations.Mutation
+import io.orangebuffalo.simpleaccounting.business.api.directives.RequiredAuth
+import io.orangebuffalo.simpleaccounting.business.standalonedocuments.StandaloneDocument
+import io.orangebuffalo.simpleaccounting.business.standalonedocuments.StandaloneDocumentsService
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import org.springframework.stereotype.Component
+import org.springframework.validation.annotation.Validated
+
+@Component
+@Validated
+class CreateStandaloneDocumentMutation(
+    private val standaloneDocumentsService: StandaloneDocumentsService,
+) : Mutation {
+
+    @Suppress("unused")
+    @GraphQLDescription("Creates a new standalone document in the specified workspace.")
+    @RequiredAuth(RequiredAuth.AuthType.REGULAR_USER)
+    suspend fun createStandaloneDocument(
+        @GraphQLDescription("ID of the workspace to create the standalone document in.")
+        workspaceId: String,
+        @GraphQLDescription("Title of the standalone document.")
+        @NotBlank
+        @Size(max = 255)
+        title: String,
+        @GraphQLDescription("ID of the linked document.")
+        documentId: String,
+    ): StandaloneDocumentGqlDto = standaloneDocumentsService.createStandaloneDocument(
+        workspaceId = workspaceId,
+        standaloneDocument = StandaloneDocument(
+            title = title,
+            documentId = documentId,
+        ),
+    ).toStandaloneDocumentGqlDto()
+}

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/EditStandaloneDocumentMutation.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/EditStandaloneDocumentMutation.kt
@@ -1,0 +1,45 @@
+package io.orangebuffalo.simpleaccounting.business.api.standalonedocuments
+
+import com.expediagroup.graphql.generator.annotations.GraphQLDescription
+import com.expediagroup.graphql.server.operations.Mutation
+import io.orangebuffalo.simpleaccounting.business.api.directives.RequiredAuth
+import io.orangebuffalo.simpleaccounting.business.common.exceptions.EntityNotFoundException
+import io.orangebuffalo.simpleaccounting.business.standalonedocuments.StandaloneDocumentsService
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import org.springframework.stereotype.Component
+import org.springframework.validation.annotation.Validated
+
+@Component
+@Validated
+class EditStandaloneDocumentMutation(
+    private val standaloneDocumentsService: StandaloneDocumentsService,
+) : Mutation {
+
+    @Suppress("unused")
+    @GraphQLDescription("Updates an existing standalone document in the specified workspace.")
+    @RequiredAuth(RequiredAuth.AuthType.REGULAR_USER)
+    suspend fun editStandaloneDocument(
+        @GraphQLDescription("ID of the workspace the standalone document belongs to.")
+        workspaceId: String,
+        @GraphQLDescription("ID of the standalone document to update.")
+        id: String,
+        @GraphQLDescription("New title of the standalone document.")
+        @NotBlank
+        @Size(max = 255)
+        title: String,
+        @GraphQLDescription("New ID of the linked document.")
+        documentId: String,
+    ): StandaloneDocumentGqlDto {
+        val standaloneDocument = standaloneDocumentsService.getStandaloneDocumentByIdAndWorkspaceId(id, workspaceId)
+            ?: throw EntityNotFoundException("Standalone document $id is not found")
+
+        return standaloneDocumentsService.saveStandaloneDocument(
+            workspaceId = workspaceId,
+            standaloneDocument = standaloneDocument.copy(
+                title = title,
+                documentId = documentId,
+            ),
+        ).toStandaloneDocumentGqlDto()
+    }
+}

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/StandaloneDocumentByWorkspaceAndIdDataLoader.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/StandaloneDocumentByWorkspaceAndIdDataLoader.kt
@@ -1,0 +1,58 @@
+package io.orangebuffalo.simpleaccounting.business.api.standalonedocuments
+
+import com.expediagroup.graphql.dataloader.KotlinDataLoader
+import graphql.GraphQLContext
+import graphql.schema.DataFetchingEnvironment
+import io.orangebuffalo.simpleaccounting.infra.graphql.newAsyncMappedDataLoader
+import io.orangebuffalo.simpleaccounting.services.persistence.model.Tables
+import org.dataloader.DataLoader
+import org.jooq.DSLContext
+import org.springframework.stereotype.Component
+import java.util.concurrent.CompletableFuture
+
+data class WorkspaceStandaloneDocumentKey(val workspaceId: String, val standaloneDocumentId: String)
+
+private const val NAME = "standaloneDocumentByWorkspaceAndId"
+
+@Component
+class StandaloneDocumentByWorkspaceAndIdDataLoader(
+    private val dslContext: DSLContext,
+) : KotlinDataLoader<WorkspaceStandaloneDocumentKey, StandaloneDocumentGqlDto?> {
+
+    private val standaloneDocument = Tables.STANDALONE_DOCUMENT
+    private val document = Tables.DOCUMENT
+
+    override val dataLoaderName: String = NAME
+
+    override fun getDataLoader(graphQLContext: GraphQLContext): DataLoader<WorkspaceStandaloneDocumentKey, StandaloneDocumentGqlDto?> =
+        newAsyncMappedDataLoader { keys ->
+            val standaloneDocumentIds = keys.map { it.standaloneDocumentId }.toSet()
+            val workspaceIds = keys.map { it.workspaceId }.toSet()
+
+            val dtosByKey = dslContext
+                .select(standaloneDocument.fields().toList() + document.workspaceId)
+                .from(standaloneDocument)
+                .join(document).on(document.id.eq(standaloneDocument.documentId))
+                .where(standaloneDocument.id.`in`(standaloneDocumentIds))
+                .and(document.workspaceId.`in`(workspaceIds))
+                .fetch()
+                .associate { record ->
+                    val standaloneDocumentId = record[standaloneDocument.id]!!
+                    val workspaceId = record[document.workspaceId]!!
+                    WorkspaceStandaloneDocumentKey(workspaceId, standaloneDocumentId) to StandaloneDocumentGqlDto(
+                        id = standaloneDocumentId,
+                        title = record[standaloneDocument.title]!!,
+                        documentId = record[standaloneDocument.documentId]!!,
+                    )
+                }
+
+            keys.associateWith { key -> dtosByKey[key] }
+        }
+}
+
+fun DataFetchingEnvironment.loadStandaloneDocumentByWorkspaceAndId(
+    workspaceId: String,
+    standaloneDocumentId: String,
+): CompletableFuture<StandaloneDocumentGqlDto?> =
+    getDataLoader<WorkspaceStandaloneDocumentKey, StandaloneDocumentGqlDto?>(NAME)!!
+        .load(WorkspaceStandaloneDocumentKey(workspaceId, standaloneDocumentId))

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/StandaloneDocumentByWorkspaceAndIdDataLoader.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/StandaloneDocumentByWorkspaceAndIdDataLoader.kt
@@ -7,6 +7,7 @@ import io.orangebuffalo.simpleaccounting.infra.graphql.newAsyncMappedDataLoader
 import io.orangebuffalo.simpleaccounting.services.persistence.model.Tables
 import org.dataloader.DataLoader
 import org.jooq.DSLContext
+import org.jooq.impl.DSL
 import org.springframework.stereotype.Component
 import java.util.concurrent.CompletableFuture
 
@@ -26,15 +27,16 @@ class StandaloneDocumentByWorkspaceAndIdDataLoader(
 
     override fun getDataLoader(graphQLContext: GraphQLContext): DataLoader<WorkspaceStandaloneDocumentKey, StandaloneDocumentGqlDto?> =
         newAsyncMappedDataLoader { keys ->
-            val standaloneDocumentIds = keys.map { it.standaloneDocumentId }.toSet()
-            val workspaceIds = keys.map { it.workspaceId }.toSet()
+            val requestedPairsPredicate = DSL.or(keys.map { key ->
+                standaloneDocument.id.eq(key.standaloneDocumentId)
+                    .and(document.workspaceId.eq(key.workspaceId))
+            })
 
             val dtosByKey = dslContext
                 .select(standaloneDocument.fields().toList() + document.workspaceId)
                 .from(standaloneDocument)
                 .join(document).on(document.id.eq(standaloneDocument.documentId))
-                .where(standaloneDocument.id.`in`(standaloneDocumentIds))
-                .and(document.workspaceId.`in`(workspaceIds))
+                .where(requestedPairsPredicate)
                 .fetch()
                 .associate { record ->
                     val standaloneDocumentId = record[standaloneDocument.id]!!

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/StandaloneDocumentGqlDto.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/StandaloneDocumentGqlDto.kt
@@ -1,0 +1,24 @@
+package io.orangebuffalo.simpleaccounting.business.api.standalonedocuments
+
+import com.expediagroup.graphql.generator.annotations.GraphQLDescription
+import com.expediagroup.graphql.generator.annotations.GraphQLName
+import io.orangebuffalo.simpleaccounting.business.standalonedocuments.StandaloneDocument
+
+@GraphQLName("StandaloneDocument")
+@GraphQLDescription("A standalone document in a workspace.")
+data class StandaloneDocumentGqlDto(
+    @GraphQLDescription("ID of the standalone document.")
+    val id: String,
+
+    @GraphQLDescription("Title of the standalone document.")
+    val title: String,
+
+    @GraphQLDescription("ID of the linked document.")
+    val documentId: String,
+)
+
+fun StandaloneDocument.toStandaloneDocumentGqlDto() = StandaloneDocumentGqlDto(
+    id = id!!,
+    title = title,
+    documentId = documentId,
+)

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/StandaloneDocumentsGqlApi.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/StandaloneDocumentsGqlApi.kt
@@ -1,0 +1,30 @@
+package io.orangebuffalo.simpleaccounting.business.api.standalonedocuments
+
+import io.orangebuffalo.simpleaccounting.infra.graphql.connections.ConnectionGqlDto
+import io.orangebuffalo.simpleaccounting.infra.graphql.connections.GraphqlPaginationService
+import io.orangebuffalo.simpleaccounting.services.persistence.model.Tables
+import org.springframework.stereotype.Component
+
+@Component
+class StandaloneDocumentsGqlApi(
+    private val paginationService: GraphqlPaginationService,
+) {
+    private val standaloneDocument = Tables.STANDALONE_DOCUMENT
+    private val document = Tables.DOCUMENT
+
+    suspend fun loadStandaloneDocuments(
+        workspaceId: String,
+        first: Int,
+        after: String?,
+    ): ConnectionGqlDto<StandaloneDocumentGqlDto> = paginationService
+        .forTable(standaloneDocument)
+        .onQuery { it.join(document).on(document.id.eq(standaloneDocument.documentId)) }
+        .addPredicate(document.workspaceId.eq(workspaceId))
+        .page(first, after) { record ->
+            StandaloneDocumentGqlDto(
+                id = record[standaloneDocument.id]!!,
+                title = record[standaloneDocument.title]!!,
+                documentId = record[standaloneDocument.documentId]!!,
+            )
+        }
+}

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/workspaces/WorkspaceGqlDto.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/workspaces/WorkspaceGqlDto.kt
@@ -17,6 +17,8 @@ import io.orangebuffalo.simpleaccounting.business.api.incomes.IncomesGqlApi
 import io.orangebuffalo.simpleaccounting.business.api.invoices.InvoiceGqlDto
 import io.orangebuffalo.simpleaccounting.business.api.invoices.InvoicesGqlApi
 import io.orangebuffalo.simpleaccounting.business.invoices.InvoiceStatus
+import io.orangebuffalo.simpleaccounting.business.api.standalonedocuments.StandaloneDocumentGqlDto
+import io.orangebuffalo.simpleaccounting.business.api.standalonedocuments.StandaloneDocumentsGqlApi
 import io.orangebuffalo.simpleaccounting.business.api.generaltaxes.GeneralTaxGqlDto
 import io.orangebuffalo.simpleaccounting.business.api.generaltaxes.loadGeneralTaxByWorkspaceAndId
 import io.orangebuffalo.simpleaccounting.business.api.incometaxpayments.IncomeTaxPaymentGqlDto
@@ -266,6 +268,20 @@ data class WorkspaceGqlDto(
         @GraphQLDescription("ID of the income tax payment.") id: String,
         env: DataFetchingEnvironment,
     ) = env.loadIncomeTaxPaymentByWorkspaceAndId(workspaceId = this.id, paymentId = id)
+
+    @Suppress("unused")
+    @GraphQLDescription("Standalone documents in this workspace with cursor-based pagination.")
+    suspend fun standaloneDocuments(
+        @GraphQLDescription("The maximum number of items to return.")
+        @Min(GraphqlPaginationConstants.PAGE_SIZE_MIN)
+        @Max(GraphqlPaginationConstants.PAGE_SIZE_MAX)
+        first: Int,
+        @GraphQLDescription("Cursor after which to return items.") after: String? = null,
+        env: DataFetchingEnvironment,
+    ): ConnectionGqlDto<StandaloneDocumentGqlDto> {
+        return env.graphQlContext.getBean<StandaloneDocumentsGqlApi>()
+            .loadStandaloneDocuments(workspaceId = id, first = first, after = after)
+    }
 
     @Suppress("unused")
     @GraphQLDescription("General taxes in this workspace with cursor-based pagination.")

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/workspaces/WorkspaceGqlDto.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/workspaces/WorkspaceGqlDto.kt
@@ -19,6 +19,7 @@ import io.orangebuffalo.simpleaccounting.business.api.invoices.InvoicesGqlApi
 import io.orangebuffalo.simpleaccounting.business.invoices.InvoiceStatus
 import io.orangebuffalo.simpleaccounting.business.api.standalonedocuments.StandaloneDocumentGqlDto
 import io.orangebuffalo.simpleaccounting.business.api.standalonedocuments.StandaloneDocumentsGqlApi
+import io.orangebuffalo.simpleaccounting.business.api.standalonedocuments.loadStandaloneDocumentByWorkspaceAndId
 import io.orangebuffalo.simpleaccounting.business.api.generaltaxes.GeneralTaxGqlDto
 import io.orangebuffalo.simpleaccounting.business.api.generaltaxes.loadGeneralTaxByWorkspaceAndId
 import io.orangebuffalo.simpleaccounting.business.api.incometaxpayments.IncomeTaxPaymentGqlDto
@@ -33,6 +34,7 @@ import io.orangebuffalo.simpleaccounting.services.persistence.model.Tables
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import org.jooq.DSLContext
+import java.util.concurrent.CompletableFuture
 
 @GraphQLName("Workspace")
 @GraphQLDescription("Workspace of a user.")
@@ -282,6 +284,13 @@ data class WorkspaceGqlDto(
         return env.graphQlContext.getBean<StandaloneDocumentsGqlApi>()
             .loadStandaloneDocuments(workspaceId = id, first = first, after = after)
     }
+
+    @GraphQLDescription("Returns a standalone document by its ID if it belongs to this workspace, or null if not found.")
+    fun standaloneDocument(
+        @GraphQLDescription("ID of the standalone document.") id: String,
+        env: DataFetchingEnvironment,
+    ): CompletableFuture<StandaloneDocumentGqlDto?> =
+        env.loadStandaloneDocumentByWorkspaceAndId(workspaceId = this.id, standaloneDocumentId = id)
 
     @Suppress("unused")
     @GraphQLDescription("General taxes in this workspace with cursor-based pagination.")

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/impl/DocumentsRepositoryExtImpl.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/documents/impl/DocumentsRepositoryExtImpl.kt
@@ -28,6 +28,7 @@ class DocumentsRepositoryExtImpl(
     private val income = Tables.INCOME
     private val invoice = Tables.INVOICE
     private val incomeTaxPayment = Tables.INCOME_TAX_PAYMENT
+    private val standaloneDocument = Tables.STANDALONE_DOCUMENT
 
     override fun findValidIds(ids: Collection<String>, workspaceId: String): Collection<String> = dslContext
         .select(document.id)
@@ -102,6 +103,16 @@ class DocumentsRepositoryExtImpl(
                     .from(itpa)
                     .join(incomeTaxPayment).on(incomeTaxPayment.id.eq(itpa.incomeTaxPaymentId))
                     .where(itpa.documentId.`in`(documentIds))
+            )
+            .unionAll(
+                select(
+                    standaloneDocument.documentId.`as`("doc_id"),
+                    standaloneDocument.id.`as`("entity_id"),
+                    inline("STANDALONE_DOCUMENT").`as`("usage_type"),
+                    standaloneDocument.title.`as`("display_name"),
+                )
+                    .from(standaloneDocument)
+                    .where(standaloneDocument.documentId.`in`(documentIds))
             )
             .orderBy(docIdField, usageTypeField, entityIdField)
             .fetch()

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/standalonedocuments/StandaloneDocument.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/standalonedocuments/StandaloneDocument.kt
@@ -1,0 +1,14 @@
+package io.orangebuffalo.simpleaccounting.business.standalonedocuments
+
+import io.orangebuffalo.simpleaccounting.business.common.pesistence.AbstractEntity
+import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
+
+@Table
+data class StandaloneDocument(
+    val title: String,
+    val documentId: String,
+    override val id: String? = null,
+    override val version: Int? = null,
+    override val createdAt: Instant? = null,
+) : AbstractEntity()

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/standalonedocuments/StandaloneDocument.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/standalonedocuments/StandaloneDocument.kt
@@ -4,6 +4,12 @@ import io.orangebuffalo.simpleaccounting.business.common.pesistence.AbstractEnti
 import org.springframework.data.relational.core.mapping.Table
 import java.time.Instant
 
+/**
+ * Represents a user-managed document entry that exists independently from incomes, expenses, invoices, or tax payments.
+ *
+ * The entity stores the user-facing title and references the uploaded [io.orangebuffalo.simpleaccounting.business.documents.Document]
+ * that contains the actual file metadata and storage location.
+ */
 @Table
 data class StandaloneDocument(
     val title: String,

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/standalonedocuments/StandaloneDocumentsRepository.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/standalonedocuments/StandaloneDocumentsRepository.kt
@@ -1,0 +1,9 @@
+package io.orangebuffalo.simpleaccounting.business.standalonedocuments
+
+import io.orangebuffalo.simpleaccounting.business.common.pesistence.AbstractEntityRepository
+
+interface StandaloneDocumentsRepository : AbstractEntityRepository<StandaloneDocument>, StandaloneDocumentsRepositoryExt
+
+interface StandaloneDocumentsRepositoryExt {
+    fun findByIdAndWorkspaceId(id: String, workspaceId: String): StandaloneDocument?
+}

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/standalonedocuments/StandaloneDocumentsService.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/standalonedocuments/StandaloneDocumentsService.kt
@@ -1,0 +1,31 @@
+package io.orangebuffalo.simpleaccounting.business.standalonedocuments
+
+import io.orangebuffalo.simpleaccounting.business.documents.DocumentsService
+import io.orangebuffalo.simpleaccounting.business.workspaces.WorkspaceAccessMode
+import io.orangebuffalo.simpleaccounting.business.workspaces.WorkspacesService
+import io.orangebuffalo.simpleaccounting.infra.withDbContext
+import org.springframework.stereotype.Service
+
+@Service
+class StandaloneDocumentsService(
+    private val standaloneDocumentsRepository: StandaloneDocumentsRepository,
+    private val documentsService: DocumentsService,
+    private val workspacesService: WorkspacesService,
+) {
+
+    suspend fun createStandaloneDocument(workspaceId: String, standaloneDocument: StandaloneDocument): StandaloneDocument {
+        workspacesService.validateWorkspaceAccess(workspaceId, WorkspaceAccessMode.READ_WRITE)
+        documentsService.validateDocuments(workspaceId, listOf(standaloneDocument.documentId))
+        return withDbContext { standaloneDocumentsRepository.save(standaloneDocument) }
+    }
+
+    suspend fun saveStandaloneDocument(workspaceId: String, standaloneDocument: StandaloneDocument): StandaloneDocument {
+        workspacesService.validateWorkspaceAccess(workspaceId, WorkspaceAccessMode.READ_WRITE)
+        documentsService.validateDocuments(workspaceId, listOf(standaloneDocument.documentId))
+        return withDbContext { standaloneDocumentsRepository.save(standaloneDocument) }
+    }
+
+    suspend fun getStandaloneDocumentByIdAndWorkspaceId(id: String, workspaceId: String): StandaloneDocument? = withDbContext {
+        standaloneDocumentsRepository.findByIdAndWorkspaceId(id, workspaceId)
+    }
+}

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/standalonedocuments/impl/StandaloneDocumentsRepositoryExtImpl.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/standalonedocuments/impl/StandaloneDocumentsRepositoryExtImpl.kt
@@ -1,0 +1,32 @@
+package io.orangebuffalo.simpleaccounting.business.standalonedocuments.impl
+
+import io.orangebuffalo.simpleaccounting.business.standalonedocuments.StandaloneDocument
+import io.orangebuffalo.simpleaccounting.business.standalonedocuments.StandaloneDocumentsRepositoryExt
+import io.orangebuffalo.simpleaccounting.services.persistence.model.Tables
+import org.jooq.DSLContext
+import org.springframework.stereotype.Repository
+
+@Repository
+class StandaloneDocumentsRepositoryExtImpl(
+    private val dslContext: DSLContext,
+) : StandaloneDocumentsRepositoryExt {
+
+    private val standaloneDocument = Tables.STANDALONE_DOCUMENT
+    private val document = Tables.DOCUMENT
+
+    override fun findByIdAndWorkspaceId(id: String, workspaceId: String): StandaloneDocument? = dslContext
+        .select(standaloneDocument.fields().toList())
+        .from(standaloneDocument)
+        .join(document).on(document.id.eq(standaloneDocument.documentId))
+        .where(standaloneDocument.id.eq(id))
+        .and(document.workspaceId.eq(workspaceId))
+        .fetchOne { record ->
+            StandaloneDocument(
+                id = record[standaloneDocument.id]!!,
+                version = record[standaloneDocument.version]!!,
+                createdAt = record[standaloneDocument.createdAt]!!,
+                title = record[standaloneDocument.title]!!,
+                documentId = record[standaloneDocument.documentId]!!,
+            )
+        }
+}

--- a/app/src/main/resources/db/migration/V0011__Introducing_standalone_document.sql
+++ b/app/src/main/resources/db/migration/V0011__Introducing_standalone_document.sql
@@ -1,0 +1,13 @@
+create table "STANDALONE_DOCUMENT" (
+    "ID"          varchar(10)            not null,
+    "VERSION"     integer                not null,
+    "CREATED_AT"   timestamp              not null,
+    "TITLE"       character varying(255) not null,
+    "DOCUMENT_ID" varchar(10)            not null
+);
+
+alter table "STANDALONE_DOCUMENT"
+    add primary key ("ID");
+
+alter table "STANDALONE_DOCUMENT"
+    add constraint "STANDALONE_DOCUMENT_DOCUMENT_FK" foreign key ("DOCUMENT_ID") references "DOCUMENT" ("ID");

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/CreateStandaloneDocumentMutationTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/CreateStandaloneDocumentMutationTest.kt
@@ -1,0 +1,159 @@
+package io.orangebuffalo.simpleaccounting.business.api.standalonedocuments
+
+import io.orangebuffalo.simpleaccounting.SaIntegrationTestBase
+import io.orangebuffalo.simpleaccounting.business.standalonedocuments.StandaloneDocument
+import io.orangebuffalo.simpleaccounting.infra.graphql.DgsConstants
+import io.orangebuffalo.simpleaccounting.infra.graphql.client.MutationProjection
+import io.orangebuffalo.simpleaccounting.tests.infra.api.*
+import io.orangebuffalo.simpleaccounting.tests.infra.utils.MOCK_TIME
+import io.orangebuffalo.simpleaccounting.tests.infra.utils.findAll
+import io.orangebuffalo.simpleaccounting.tests.infra.utils.shouldBeEntityWithFields
+import io.orangebuffalo.simpleaccounting.tests.infra.utils.shouldBeSingle
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.beans.factory.annotation.Autowired
+
+@DisplayName("createStandaloneDocument mutation")
+class CreateStandaloneDocumentMutationTest(
+    @Autowired private val client: ApiTestClient,
+) : SaIntegrationTestBase() {
+
+    private val preconditions by lazyPreconditions {
+        object {
+            val fry = fry()
+            val fryWorkspace = workspace(owner = fry)
+            val fryDocument = document(workspace = fryWorkspace, name = "Slurm receipt")
+            val farnsworth = farnsworth()
+            val workspaceAccessToken = workspaceAccessToken(
+                workspace = fryWorkspace,
+                validTill = MOCK_TIME.plusSeconds(10000),
+            )
+            val zoidberg = zoidberg()
+            val zoidbergWorkspace = workspace(owner = zoidberg)
+            val zoidbergDocument = document(workspace = zoidbergWorkspace, name = "Claw polish receipt")
+        }
+    }
+
+    @Nested
+    @DisplayName("Authorization")
+    inner class Authorization {
+
+        @Test
+        fun `should return NOT_AUTHORIZED error for anonymous requests`() {
+            client
+                .graphqlMutation { createStandaloneDocumentMutation() }
+                .fromAnonymous()
+                .executeAndVerifyNotAuthorized(path = DgsConstants.MUTATION.CreateStandaloneDocument)
+        }
+
+        @Test
+        fun `should return NOT_AUTHORIZED error for admin user`() {
+            client
+                .graphqlMutation { createStandaloneDocumentMutation() }
+                .from(preconditions.farnsworth)
+                .executeAndVerifyNotAuthorized(path = DgsConstants.MUTATION.CreateStandaloneDocument)
+        }
+
+        @Test
+        fun `should return NOT_AUTHORIZED error for workspace access token`() {
+            client
+                .graphqlMutation { createStandaloneDocumentMutation() }
+                .usingSharedWorkspaceToken(preconditions.workspaceAccessToken.token)
+                .executeAndVerifyNotAuthorized(path = DgsConstants.MUTATION.CreateStandaloneDocument)
+        }
+    }
+
+    @Nested
+    @DisplayName("Inputs Validation")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class InputsValidation {
+        fun testCases() = listOf(
+            mustNotBeBlankTestCases("title") { value -> createStandaloneDocumentMutation(title = value) },
+            sizeConstraintTestCases("title", maxLength = 255) { value -> createStandaloneDocumentMutation(title = value) },
+            requiredFieldRejectedTestCases("documentId") { createStandaloneDocumentMutation() },
+            requiredFieldRejectedTestCases("title") { createStandaloneDocumentMutation() },
+            requiredFieldRejectedTestCases("workspaceId") { createStandaloneDocumentMutation() },
+        ).flatten()
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("testCases")
+        fun `should validate inputs`(testCase: GraphqlMutationInputTestCase) {
+            client
+                .buildInputValidationRequest(testCase)
+                .from(preconditions.fry)
+                .executeAndVerifyInputValidation(testCase, DgsConstants.MUTATION.CreateStandaloneDocument)
+        }
+    }
+
+    @Nested
+    @DisplayName("Business Flow")
+    inner class BusinessFlow {
+
+        @Test
+        fun `should create a new standalone document`() {
+            client
+                .graphqlMutation {
+                    createStandaloneDocumentMutation(title = "Slurm supplies receipt")
+                }
+                .from(preconditions.fry)
+                .executeAndVerifySuccessResponse(
+                    DgsConstants.MUTATION.CreateStandaloneDocument to buildJsonObject {
+                        put("title", "Slurm supplies receipt")
+                        put("documentId", preconditions.fryDocument.id!!)
+                    }
+                )
+
+            aggregateTemplate.findAll<StandaloneDocument>()
+                .filter { it.title == "Slurm supplies receipt" }
+                .shouldBeSingle()
+                .shouldBeEntityWithFields(
+                    StandaloneDocument(
+                        title = "Slurm supplies receipt",
+                        documentId = preconditions.fryDocument.id!!,
+                    )
+                )
+        }
+
+        @Test
+        fun `should return entity not found error for document in another workspace`() {
+            client
+                .graphqlMutation {
+                    createStandaloneDocumentMutation(documentId = preconditions.zoidbergDocument.id!!)
+                }
+                .from(preconditions.fry)
+                .executeAndVerifyEntityNotFoundError(path = DgsConstants.MUTATION.CreateStandaloneDocument)
+        }
+
+        @Test
+        fun `should return entity not found error for another user workspace`() {
+            client
+                .graphqlMutation {
+                    createStandaloneDocumentMutation(
+                        workspaceId = preconditions.zoidbergWorkspace.id!!,
+                        documentId = preconditions.zoidbergDocument.id!!,
+                    )
+                }
+                .from(preconditions.fry)
+                .executeAndVerifyEntityNotFoundError(path = DgsConstants.MUTATION.CreateStandaloneDocument)
+        }
+    }
+
+    private fun MutationProjection.createStandaloneDocumentMutation(
+        workspaceId: String = preconditions.fryWorkspace.id!!,
+        title: String = "Delivery receipt",
+        documentId: String = preconditions.fryDocument.id!!,
+    ): MutationProjection = createStandaloneDocument(
+        workspaceId = workspaceId,
+        title = title,
+        documentId = documentId,
+    ) {
+        this.title
+        this.documentId
+    }
+}

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/EditStandaloneDocumentMutationTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/EditStandaloneDocumentMutationTest.kt
@@ -1,0 +1,182 @@
+package io.orangebuffalo.simpleaccounting.business.api.standalonedocuments
+
+import io.orangebuffalo.simpleaccounting.SaIntegrationTestBase
+import io.orangebuffalo.simpleaccounting.business.standalonedocuments.StandaloneDocument
+import io.orangebuffalo.simpleaccounting.infra.graphql.DgsConstants
+import io.orangebuffalo.simpleaccounting.infra.graphql.client.MutationProjection
+import io.orangebuffalo.simpleaccounting.tests.infra.api.*
+import io.orangebuffalo.simpleaccounting.tests.infra.utils.MOCK_TIME
+import io.orangebuffalo.simpleaccounting.tests.infra.utils.findSingle
+import io.orangebuffalo.simpleaccounting.tests.infra.utils.shouldBeEntityWithFields
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.beans.factory.annotation.Autowired
+
+@DisplayName("editStandaloneDocument mutation")
+class EditStandaloneDocumentMutationTest(
+    @Autowired private val client: ApiTestClient,
+) : SaIntegrationTestBase() {
+
+    private val preconditions by lazyPreconditions {
+        object {
+            val fry = fry()
+            val fryWorkspace = workspace(owner = fry)
+            val fryDocument = document(workspace = fryWorkspace, name = "Slurm receipt")
+            val replacementDocument = document(workspace = fryWorkspace, name = "Robot oil receipt")
+            val standaloneDocument = standaloneDocument(
+                workspace = fryWorkspace,
+                document = fryDocument,
+                title = "Old delivery receipt",
+            )
+            val farnsworth = farnsworth()
+            val workspaceAccessToken = workspaceAccessToken(
+                workspace = fryWorkspace,
+                validTill = MOCK_TIME.plusSeconds(10000),
+            )
+            val zoidberg = zoidberg()
+            val zoidbergWorkspace = workspace(owner = zoidberg)
+            val zoidbergDocument = document(workspace = zoidbergWorkspace, name = "Claw polish receipt")
+            val zoidbergStandaloneDocument = standaloneDocument(
+                workspace = zoidbergWorkspace,
+                document = zoidbergDocument,
+                title = "Zoidberg receipt",
+            )
+        }
+    }
+
+    @Nested
+    @DisplayName("Authorization")
+    inner class Authorization {
+
+        @Test
+        fun `should return NOT_AUTHORIZED error for anonymous requests`() {
+            client
+                .graphqlMutation { editStandaloneDocumentMutation() }
+                .fromAnonymous()
+                .executeAndVerifyNotAuthorized(path = DgsConstants.MUTATION.EditStandaloneDocument)
+        }
+
+        @Test
+        fun `should return NOT_AUTHORIZED error for admin user`() {
+            client
+                .graphqlMutation { editStandaloneDocumentMutation() }
+                .from(preconditions.farnsworth)
+                .executeAndVerifyNotAuthorized(path = DgsConstants.MUTATION.EditStandaloneDocument)
+        }
+
+        @Test
+        fun `should return NOT_AUTHORIZED error for workspace access token`() {
+            client
+                .graphqlMutation { editStandaloneDocumentMutation() }
+                .usingSharedWorkspaceToken(preconditions.workspaceAccessToken.token)
+                .executeAndVerifyNotAuthorized(path = DgsConstants.MUTATION.EditStandaloneDocument)
+        }
+    }
+
+    @Nested
+    @DisplayName("Inputs Validation")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class InputsValidation {
+        fun testCases() = listOf(
+            mustNotBeBlankTestCases("title") { value -> editStandaloneDocumentMutation(title = value) },
+            sizeConstraintTestCases("title", maxLength = 255) { value -> editStandaloneDocumentMutation(title = value) },
+            requiredFieldRejectedTestCases("documentId") { editStandaloneDocumentMutation() },
+            requiredFieldRejectedTestCases("id") { editStandaloneDocumentMutation() },
+            requiredFieldRejectedTestCases("title") { editStandaloneDocumentMutation() },
+            requiredFieldRejectedTestCases("workspaceId") { editStandaloneDocumentMutation() },
+        ).flatten()
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("testCases")
+        fun `should validate inputs`(testCase: GraphqlMutationInputTestCase) {
+            client
+                .buildInputValidationRequest(testCase)
+                .from(preconditions.fry)
+                .executeAndVerifyInputValidation(testCase, DgsConstants.MUTATION.EditStandaloneDocument)
+        }
+    }
+
+    @Nested
+    @DisplayName("Business Flow")
+    inner class BusinessFlow {
+
+        @Test
+        fun `should update standalone document`() {
+            client
+                .graphqlMutation {
+                    editStandaloneDocumentMutation(
+                        title = "Updated robot oil receipt",
+                        documentId = preconditions.replacementDocument.id!!,
+                    )
+                }
+                .from(preconditions.fry)
+                .executeAndVerifySuccessResponse(
+                    DgsConstants.MUTATION.EditStandaloneDocument to buildJsonObject {
+                        put("id", preconditions.standaloneDocument.id!!)
+                        put("title", "Updated robot oil receipt")
+                        put("documentId", preconditions.replacementDocument.id!!)
+                    }
+                )
+
+            aggregateTemplate.findSingle<StandaloneDocument>(preconditions.standaloneDocument.id!!)
+                .shouldBeEntityWithFields(
+                    StandaloneDocument(
+                        title = "Updated robot oil receipt",
+                        documentId = preconditions.replacementDocument.id!!,
+                    )
+                )
+        }
+
+        @Test
+        fun `should return entity not found error for non-existent standalone document`() {
+            client
+                .graphqlMutation { editStandaloneDocumentMutation(id = "missing-id") }
+                .from(preconditions.fry)
+                .executeAndVerifyEntityNotFoundError(path = DgsConstants.MUTATION.EditStandaloneDocument)
+        }
+
+        @Test
+        fun `should return entity not found error for standalone document in another user workspace`() {
+            client
+                .graphqlMutation {
+                    editStandaloneDocumentMutation(
+                        workspaceId = preconditions.zoidbergWorkspace.id!!,
+                        id = preconditions.zoidbergStandaloneDocument.id!!,
+                        documentId = preconditions.zoidbergDocument.id!!,
+                    )
+                }
+                .from(preconditions.fry)
+                .executeAndVerifyEntityNotFoundError(path = DgsConstants.MUTATION.EditStandaloneDocument)
+        }
+
+        @Test
+        fun `should return entity not found error for document in another workspace`() {
+            client
+                .graphqlMutation { editStandaloneDocumentMutation(documentId = preconditions.zoidbergDocument.id!!) }
+                .from(preconditions.fry)
+                .executeAndVerifyEntityNotFoundError(path = DgsConstants.MUTATION.EditStandaloneDocument)
+        }
+    }
+
+    private fun MutationProjection.editStandaloneDocumentMutation(
+        workspaceId: String = preconditions.fryWorkspace.id!!,
+        id: String = preconditions.standaloneDocument.id!!,
+        title: String = "Delivery receipt",
+        documentId: String = preconditions.fryDocument.id!!,
+    ): MutationProjection = editStandaloneDocument(
+        workspaceId = workspaceId,
+        id = id,
+        title = title,
+        documentId = documentId,
+    ) {
+        this.id
+        this.title
+        this.documentId
+    }
+}

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/StandaloneDocumentsQueryTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/StandaloneDocumentsQueryTest.kt
@@ -4,6 +4,7 @@ import io.orangebuffalo.simpleaccounting.SaIntegrationTestBase
 import io.orangebuffalo.simpleaccounting.infra.graphql.connections.encodeCursor
 import io.orangebuffalo.simpleaccounting.tests.infra.api.ApiTestClient
 import io.orangebuffalo.simpleaccounting.tests.infra.api.graphql
+import io.orangebuffalo.simpleaccounting.tests.infra.api.graphqlRawQuery
 import io.orangebuffalo.simpleaccounting.tests.infra.database.EntitiesFactory
 import io.orangebuffalo.simpleaccounting.tests.infra.utils.MOCK_TIME
 import kotlinx.serialization.json.buildJsonObject
@@ -207,6 +208,76 @@ class StandaloneDocumentsQueryTest(
                                 })
                             }
                         })
+                    }
+                )
+        }
+
+        @Test
+        fun `should return standalone document by id`() {
+            val testData = preconditions {
+                object {
+                    val fry = fry()
+                    val workspace = workspace(owner = fry)
+                    val document = document(workspace = workspace, name = "Slurm receipt")
+                    val standaloneDocument = standaloneDocument(
+                        document = document,
+                        title = "Slurm supplies",
+                    )
+                }
+            }
+            client.graphqlRawQuery(
+                """
+                    query {
+                      workspace(id: "${testData.workspace.id!!}") {
+                        standaloneDocument(id: "${testData.standaloneDocument.id!!}") {
+                          id
+                          title
+                          documentId
+                        }
+                      }
+                    }
+                """.trimIndent()
+            )
+                .from(testData.fry)
+                .executeAndVerifyResponse(
+                    "workspace" to buildJsonObject {
+                        put("standaloneDocument", buildJsonObject {
+                            put("id", testData.standaloneDocument.id!!)
+                            put("title", "Slurm supplies")
+                            put("documentId", testData.document.id!!)
+                        })
+                    }
+                )
+        }
+
+        @Test
+        fun `should return null when standalone document belongs to another workspace`() {
+            val testData = preconditions {
+                object {
+                    val fry = fry()
+                    val workspace = workspace(owner = fry)
+                    val otherWorkspace = workspace(owner = fry)
+                    val otherStandaloneDocument = standaloneDocument(
+                        document = document(workspace = otherWorkspace),
+                        title = "Moon cargo receipt",
+                    )
+                }
+            }
+            client.graphqlRawQuery(
+                """
+                    query {
+                      workspace(id: "${testData.workspace.id!!}") {
+                        standaloneDocument(id: "${testData.otherStandaloneDocument.id!!}") {
+                          id
+                        }
+                      }
+                    }
+                """.trimIndent()
+            )
+                .from(testData.fry)
+                .executeAndVerifyResponse(
+                    "workspace" to buildJsonObject {
+                        put("standaloneDocument", null as String?)
                     }
                 )
         }

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/StandaloneDocumentsQueryTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/StandaloneDocumentsQueryTest.kt
@@ -1,0 +1,220 @@
+package io.orangebuffalo.simpleaccounting.business.api.standalonedocuments
+
+import io.orangebuffalo.simpleaccounting.SaIntegrationTestBase
+import io.orangebuffalo.simpleaccounting.infra.graphql.connections.encodeCursor
+import io.orangebuffalo.simpleaccounting.tests.infra.api.ApiTestClient
+import io.orangebuffalo.simpleaccounting.tests.infra.api.graphql
+import io.orangebuffalo.simpleaccounting.tests.infra.database.EntitiesFactory
+import io.orangebuffalo.simpleaccounting.tests.infra.utils.MOCK_TIME
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class StandaloneDocumentsQueryTest(
+    @Autowired private val client: ApiTestClient,
+) : SaIntegrationTestBase() {
+
+    @Nested
+    @DisplayName("Pagination")
+    inner class Pagination {
+
+        private fun EntitiesFactory.threeStandaloneDocuments() = object {
+            val fry = fry()
+            val workspace = workspace(owner = fry)
+            val document1 = document(workspace = workspace, name = "Delivery receipt")
+            val document2 = document(workspace = workspace, name = "Robot oil receipt")
+            val document3 = document(workspace = workspace, name = "Slurm receipt")
+            val standaloneDocument1 = standaloneDocument(
+                document = document1,
+                title = "Delivery to Mars",
+                createdAt = MOCK_TIME.plusSeconds(100),
+            )
+            val standaloneDocument2 = standaloneDocument(
+                document = document2,
+                title = "Robot maintenance",
+                createdAt = MOCK_TIME.plusSeconds(200),
+            )
+            val standaloneDocument3 = standaloneDocument(
+                document = document3,
+                title = "Slurm supplies",
+                createdAt = MOCK_TIME.plusSeconds(300),
+            )
+        }
+
+        @Test
+        fun `should return first page with pageInfo`() {
+            val testData = preconditions { threeStandaloneDocuments() }
+            client.graphql {
+                workspace(id = testData.workspace.id!!) {
+                    standaloneDocuments(first = 2) {
+                        edges {
+                            cursor
+                            node { title }
+                        }
+                        pageInfo {
+                            startCursor
+                            endCursor
+                            hasPreviousPage
+                            hasNextPage
+                        }
+                        totalCount
+                    }
+                }
+            }
+                .from(testData.fry)
+                .executeAndVerifyResponse(
+                    "workspace" to buildJsonObject {
+                        put("standaloneDocuments", buildJsonObject {
+                            putJsonArray("edges") {
+                                add(buildJsonObject {
+                                    put("cursor", encodeCursor(testData.standaloneDocument3.createdAt!!))
+                                    put("node", buildJsonObject { put("title", "Slurm supplies") })
+                                })
+                                add(buildJsonObject {
+                                    put("cursor", encodeCursor(testData.standaloneDocument2.createdAt!!))
+                                    put("node", buildJsonObject { put("title", "Robot maintenance") })
+                                })
+                            }
+                            put("pageInfo", buildJsonObject {
+                                put("startCursor", encodeCursor(testData.standaloneDocument3.createdAt!!))
+                                put("endCursor", encodeCursor(testData.standaloneDocument2.createdAt!!))
+                                put("hasPreviousPage", false)
+                                put("hasNextPage", true)
+                            })
+                            put("totalCount", 3)
+                        })
+                    }
+                )
+        }
+
+        @Test
+        fun `should return second page using after cursor`() {
+            val testData = preconditions { threeStandaloneDocuments() }
+            client.graphql {
+                workspace(id = testData.workspace.id!!) {
+                    standaloneDocuments(first = 10, after = encodeCursor(testData.standaloneDocument2.createdAt!!)) {
+                        edges {
+                            node { title }
+                        }
+                        pageInfo {
+                            hasPreviousPage
+                            hasNextPage
+                        }
+                        totalCount
+                    }
+                }
+            }
+                .from(testData.fry)
+                .executeAndVerifyResponse(
+                    "workspace" to buildJsonObject {
+                        put("standaloneDocuments", buildJsonObject {
+                            putJsonArray("edges") {
+                                standaloneDocumentEdge(title = "Delivery to Mars")
+                            }
+                            put("pageInfo", buildJsonObject {
+                                put("hasPreviousPage", true)
+                                put("hasNextPage", false)
+                            })
+                            put("totalCount", 3)
+                        })
+                    }
+                )
+        }
+
+        @Test
+        fun `should not include standalone documents from other workspaces`() {
+            val testData = preconditions {
+                object {
+                    val fry = fry()
+                    val workspace = workspace(owner = fry)
+                    val document = document(workspace = workspace)
+                    val standaloneDocument = standaloneDocument(
+                        document = document,
+                        title = "Delivery to Mars",
+                    )
+                }.also {
+                    val otherWorkspace = workspace(owner = zoidberg())
+                    standaloneDocument(
+                        document = document(workspace = otherWorkspace),
+                        title = "Doctor supplies",
+                    )
+                }
+            }
+            client.graphql {
+                workspace(id = testData.workspace.id!!) {
+                    standaloneDocuments(first = 10) {
+                        edges {
+                            node { title }
+                        }
+                        totalCount
+                    }
+                }
+            }
+                .from(testData.fry)
+                .executeAndVerifyResponse(
+                    "workspace" to buildJsonObject {
+                        put("standaloneDocuments", buildJsonObject {
+                            putJsonArray("edges") {
+                                standaloneDocumentEdge(title = "Delivery to Mars")
+                            }
+                            put("totalCount", 1)
+                        })
+                    }
+                )
+        }
+
+        @Test
+        fun `should return all standalone document fields`() {
+            val testData = preconditions {
+                object {
+                    val fry = fry()
+                    val workspace = workspace(owner = fry)
+                    val document = document(workspace = workspace, name = "Slurm receipt")
+                    val standaloneDocument = standaloneDocument(
+                        document = document,
+                        title = "Slurm supplies",
+                    )
+                }
+            }
+            client.graphql {
+                workspace(id = testData.workspace.id!!) {
+                    standaloneDocuments(first = 10) {
+                        edges {
+                            node {
+                                id
+                                title
+                                documentId
+                            }
+                        }
+                    }
+                }
+            }
+                .from(testData.fry)
+                .executeAndVerifyResponse(
+                    "workspace" to buildJsonObject {
+                        put("standaloneDocuments", buildJsonObject {
+                            putJsonArray("edges") {
+                                add(buildJsonObject {
+                                    put("node", buildJsonObject {
+                                        put("id", testData.standaloneDocument.id!!)
+                                        put("title", "Slurm supplies")
+                                        put("documentId", testData.document.id!!)
+                                    })
+                                })
+                            }
+                        })
+                    }
+                )
+        }
+    }
+}
+
+private fun kotlinx.serialization.json.JsonArrayBuilder.standaloneDocumentEdge(title: String) {
+    add(buildJsonObject {
+        put("node", buildJsonObject { put("title", title) })
+    })
+}

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/tests/infra/database/EntitiesFactory.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/tests/infra/database/EntitiesFactory.kt
@@ -16,6 +16,7 @@ import io.orangebuffalo.simpleaccounting.business.incometaxpayments.IncomeTaxPay
 import io.orangebuffalo.simpleaccounting.business.invoices.Invoice
 import io.orangebuffalo.simpleaccounting.business.invoices.InvoiceAttachment
 import io.orangebuffalo.simpleaccounting.business.invoices.InvoiceStatus
+import io.orangebuffalo.simpleaccounting.business.standalonedocuments.StandaloneDocument
 import io.orangebuffalo.simpleaccounting.business.users.I18nSettings
 import io.orangebuffalo.simpleaccounting.business.users.PlatformUser
 import io.orangebuffalo.simpleaccounting.business.users.UserActivationToken
@@ -194,6 +195,20 @@ class EntitiesFactory(private val infra: EntitiesFactoryInfra) {
             income = income,
             expense = expense,
             description = description,
+            createdAt = createdAt,
+        ).save()
+    }
+
+    fun standaloneDocument(
+        title: String = "Slurm receipt",
+        document: Document? = null,
+        workspace: Workspace? = null,
+        createdAt: Instant = MOCK_TIME,
+    ): StandaloneDocument {
+        val linkedDocument = document ?: this.document(workspace = workspace)
+        return StandaloneDocument(
+            title = title,
+            documentId = linkedDocument.id!!,
             createdAt = createdAt,
         ).save()
     }

--- a/app/src/test/resources/api-schema.graphqls
+++ b/app/src/test/resources/api-schema.graphqls
@@ -798,6 +798,15 @@ type Mutation {
     "ID of the workspace to create the invoice in."
     workspaceId: String!
   ): Invoice! @auth(type : REGULAR_USER)
+  "Creates a new standalone document in the specified workspace."
+  createStandaloneDocument(
+    "ID of the linked document."
+    documentId: String!,
+    "Title of the standalone document."
+    title: String! @notBlank @size(max : 255, min : 0),
+    "ID of the workspace to create the standalone document in."
+    workspaceId: String!
+  ): StandaloneDocument! @auth(type : REGULAR_USER)
   "Creates a new user account."
   createUser(
     "Whether the new user should have admin privileges."
@@ -978,6 +987,17 @@ type Mutation {
     "ID of the workspace the invoice belongs to."
     workspaceId: String!
   ): Invoice! @auth(type : REGULAR_USER)
+  "Updates an existing standalone document in the specified workspace."
+  editStandaloneDocument(
+    "New ID of the linked document."
+    documentId: String!,
+    "ID of the standalone document to update."
+    id: String!,
+    "New title of the standalone document."
+    title: String! @notBlank @size(max : 255, min : 0),
+    "ID of the workspace the standalone document belongs to."
+    workspaceId: String!
+  ): StandaloneDocument! @auth(type : REGULAR_USER)
   "Updates an existing user's username."
   editUser(
     "ID of the user to update."
@@ -1125,6 +1145,34 @@ type Query {
 type RefreshAccessTokenResponse {
   "The new access token if authentication was successful, null otherwise."
   accessToken: String
+}
+
+"A standalone document in a workspace."
+type StandaloneDocument {
+  "ID of the linked document."
+  documentId: String!
+  "ID of the standalone document."
+  id: String!
+  "Title of the standalone document."
+  title: String!
+}
+
+"An edge in a standalone documents connection."
+type StandaloneDocumentEdge {
+  "The cursor of this edge, which can be used for pagination."
+  cursor: String!
+  "The standalone document at the end of this edge."
+  node: StandaloneDocument!
+}
+
+"A paginated connection of standalone documents following the GraphQL Cursor Connections Specification."
+type StandaloneDocumentsConnection {
+  "The list of edges in the current page."
+  edges: [StandaloneDocumentEdge!]!
+  "Pagination information about the current page."
+  pageInfo: PageInfo!
+  "The total number of items in the connection across all pages."
+  totalCount: Int!
 }
 
 type Subscription {
@@ -1285,6 +1333,13 @@ type Workspace {
   ): InvoicesConnection!
   "Name of the workspace."
   name: String!
+  "Standalone documents in this workspace with cursor-based pagination."
+  standaloneDocuments(
+    "Cursor after which to return items."
+    after: String,
+    "The maximum number of items to return."
+    first: Int!
+  ): StandaloneDocumentsConnection!
   "Workspace access tokens in this workspace with cursor-based pagination."
   workspaceAccessTokens(
     "Cursor after which to return items."
@@ -1450,6 +1505,8 @@ enum DocumentUsageType {
   INCOME_TAX_PAYMENT
   "Document is used by an invoice."
   INVOICE
+  "Document is used by a standalone document."
+  STANDALONE_DOCUMENT
 }
 
 "Possible business error codes for the editUser operation."

--- a/app/src/test/resources/api-schema.graphqls
+++ b/app/src/test/resources/api-schema.graphqls
@@ -1333,6 +1333,11 @@ type Workspace {
   ): InvoicesConnection!
   "Name of the workspace."
   name: String!
+  "Returns a standalone document by its ID if it belongs to this workspace, or null if not found."
+  standaloneDocument(
+    "ID of the standalone document."
+    id: String!
+  ): StandaloneDocument
   "Standalone documents in this workspace with cursor-based pagination."
   standaloneDocuments(
     "Cursor after which to return items."

--- a/frontend/src/pages/documents/DocumentsOverviewPanel.vue
+++ b/frontend/src/pages/documents/DocumentsOverviewPanel.vue
@@ -203,6 +203,7 @@
     INCOME: 'edit-income',
     INVOICE: 'edit-invoice',
     INCOME_TAX_PAYMENT: 'edit-income-tax-payment',
+    STANDALONE_DOCUMENT: 'documents-overview',
   };
 
   const usageTypeToIconMap: Record<DocumentUsageType, string> = {
@@ -210,6 +211,7 @@
     INCOME: 'income',
     INVOICE: 'invoices-overview',
     INCOME_TAX_PAYMENT: 'income-tax-payments-overview',
+    STANDALONE_DOCUMENT: 'documents-overview',
   };
 
   const usageIcon = (usageType: DocumentUsageType) => usageTypeToIconMap[usageType];
@@ -224,6 +226,8 @@
       return $t.value.documentsOverviewPanel.usage.invoice();
     case 'INCOME_TAX_PAYMENT':
       return $t.value.documentsOverviewPanel.usage.incomeTaxPayment();
+    case 'STANDALONE_DOCUMENT':
+      return $t.value.documentsOverviewPanel.usage.standaloneDocument();
     }
   };
 

--- a/frontend/src/services/api/gql/graphql.ts
+++ b/frontend/src/services/api/gql/graphql.ts
@@ -13,7 +13,9 @@ export type DocumentUsageType =
   /** Document is used by an income tax payment. */
   | 'INCOME_TAX_PAYMENT'
   /** Document is used by an invoice. */
-  | 'INVOICE';
+  | 'INVOICE'
+  /** Document is used by a standalone document. */
+  | 'STANDALONE_DOCUMENT';
 
 export type ExpenseStatus =
   | 'FINALIZED'

--- a/frontend/src/services/api/gql/schema-types.ts
+++ b/frontend/src/services/api/gql/schema-types.ts
@@ -252,7 +252,9 @@ export enum DocumentUsageType {
   /** Document is used by an income tax payment. */
   IncomeTaxPayment = 'INCOME_TAX_PAYMENT',
   /** Document is used by an invoice. */
-  Invoice = 'INVOICE'
+  Invoice = 'INVOICE',
+  /** Document is used by a standalone document. */
+  StandaloneDocument = 'STANDALONE_DOCUMENT'
 }
 
 /** A paginated connection of documents following the GraphQL Cursor Connections Specification. */
@@ -733,6 +735,8 @@ export type Mutation = {
   createIncomeTaxPayment: IncomeTaxPayment;
   /** Creates a new invoice in the specified workspace. */
   createInvoice: Invoice;
+  /** Creates a new standalone document in the specified workspace. */
+  createStandaloneDocument: StandaloneDocument;
   /** Creates a new user account. */
   createUser: PlatformUser;
   /** Creates a new activation token for the specified user. If an existing token is present, it will be replaced. Only accessible by admin users. */
@@ -757,6 +761,8 @@ export type Mutation = {
   editIncomeTaxPayment: IncomeTaxPayment;
   /** Updates an existing invoice in the specified workspace. */
   editInvoice: Invoice;
+  /** Updates an existing standalone document in the specified workspace. */
+  editStandaloneDocument: StandaloneDocument;
   /** Updates an existing user's username. */
   editUser: PlatformUser;
   /** Updates an existing workspace. */
@@ -904,6 +910,13 @@ export type MutationCreateInvoiceArgs = {
 };
 
 
+export type MutationCreateStandaloneDocumentArgs = {
+  documentId: Scalars['String']['input'];
+  title: Scalars['String']['input'];
+  workspaceId: Scalars['String']['input'];
+};
+
+
 export type MutationCreateUserArgs = {
   admin: Scalars['Boolean']['input'];
   userName: Scalars['String']['input'];
@@ -1019,6 +1032,14 @@ export type MutationEditInvoiceArgs = {
   generalTaxId?: InputMaybe<Scalars['String']['input']>;
   id: Scalars['String']['input'];
   notes?: InputMaybe<Scalars['String']['input']>;
+  title: Scalars['String']['input'];
+  workspaceId: Scalars['String']['input'];
+};
+
+
+export type MutationEditStandaloneDocumentArgs = {
+  documentId: Scalars['String']['input'];
+  id: Scalars['String']['input'];
   title: Scalars['String']['input'];
   workspaceId: Scalars['String']['input'];
 };
@@ -1197,6 +1218,37 @@ export enum SaveSharedWorkspaceErrorCodes {
   InvalidWorkspaceAccessToken = 'INVALID_WORKSPACE_ACCESS_TOKEN'
 }
 
+/** A standalone document in a workspace. */
+export type StandaloneDocument = {
+  __typename?: 'StandaloneDocument';
+  /** ID of the linked document. */
+  documentId: Scalars['String']['output'];
+  /** ID of the standalone document. */
+  id: Scalars['String']['output'];
+  /** Title of the standalone document. */
+  title: Scalars['String']['output'];
+};
+
+/** An edge in a standalone documents connection. */
+export type StandaloneDocumentEdge = {
+  __typename?: 'StandaloneDocumentEdge';
+  /** The cursor of this edge, which can be used for pagination. */
+  cursor: Scalars['String']['output'];
+  /** The standalone document at the end of this edge. */
+  node: StandaloneDocument;
+};
+
+/** A paginated connection of standalone documents following the GraphQL Cursor Connections Specification. */
+export type StandaloneDocumentsConnection = {
+  __typename?: 'StandaloneDocumentsConnection';
+  /** The list of edges in the current page. */
+  edges: Array<StandaloneDocumentEdge>;
+  /** Pagination information about the current page. */
+  pageInfo: PageInfo;
+  /** The total number of items in the connection across all pages. */
+  totalCount: Scalars['Int']['output'];
+};
+
 export type Subscription = {
   __typename?: 'Subscription';
   /** Subscribes to push notifications for the current user. Returns a stream of push notification messages targeted at the authenticated user or broadcast to all users. Uses the `graphql-transport-ws` WebSocket subprotocol. Clients must provide a JWT token in the `connection_init` payload: `{ "type": "connection_init", "payload": { "token": "<JWT>" } }`. Once `connection_ack` is received, subscribe with a standard `subscribe` message. */
@@ -1307,6 +1359,8 @@ export type Workspace = {
   invoices: InvoicesConnection;
   /** Name of the workspace. */
   name: Scalars['String']['output'];
+  /** Standalone documents in this workspace with cursor-based pagination. */
+  standaloneDocuments: StandaloneDocumentsConnection;
   /** Workspace access tokens in this workspace with cursor-based pagination. */
   workspaceAccessTokens: WorkspaceAccessTokensConnection;
 };
@@ -1411,6 +1465,13 @@ export type WorkspaceInvoicesArgs = {
   first: Scalars['Int']['input'];
   freeSearchText?: InputMaybe<Scalars['String']['input']>;
   statusIn?: InputMaybe<Array<InvoiceStatus>>;
+};
+
+
+/** Workspace of a user. */
+export type WorkspaceStandaloneDocumentsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
 };
 
 

--- a/frontend/src/services/api/gql/schema-types.ts
+++ b/frontend/src/services/api/gql/schema-types.ts
@@ -1359,6 +1359,8 @@ export type Workspace = {
   invoices: InvoicesConnection;
   /** Name of the workspace. */
   name: Scalars['String']['output'];
+  /** Returns a standalone document by its ID if it belongs to this workspace, or null if not found. */
+  standaloneDocument?: Maybe<StandaloneDocument>;
   /** Standalone documents in this workspace with cursor-based pagination. */
   standaloneDocuments: StandaloneDocumentsConnection;
   /** Workspace access tokens in this workspace with cursor-based pagination. */
@@ -1465,6 +1467,12 @@ export type WorkspaceInvoicesArgs = {
   first: Scalars['Int']['input'];
   freeSearchText?: InputMaybe<Scalars['String']['input']>;
   statusIn?: InputMaybe<Array<InvoiceStatus>>;
+};
+
+
+/** Workspace of a user. */
+export type WorkspaceStandaloneDocumentArgs = {
+  id: Scalars['String']['input'];
 };
 
 

--- a/frontend/src/services/i18n/t9n/en.ts
+++ b/frontend/src/services/i18n/t9n/en.ts
@@ -384,6 +384,7 @@ export default {
       income: () => 'income',
       invoice: () => 'invoice',
       incomeTaxPayment: () => 'income tax payment',
+      standaloneDocument: () => 'standalone document',
       navigateTooltip: (usageType: string) => `Click to navigate to the ${usageType}`,
     },
     actions: {

--- a/frontend/src/services/i18n/t9n/uk.ts
+++ b/frontend/src/services/i18n/t9n/uk.ts
@@ -383,6 +383,7 @@ export default {
       income: () => 'доходу',
       invoice: () => 'рахунку',
       incomeTaxPayment: () => 'платежу податку на дохід',
+      standaloneDocument: () => 'окремого документа',
       navigateTooltip: (usageType: string) => `Натисніть, щоб перейти до ${usageType}`,
     },
     actions: {


### PR DESCRIPTION
## Problem statement
We needed a first-class standalone document entity that references uploaded documents, with standard GraphQL create/edit/list access.

## Solution summary
Added the `StandaloneDocument` entity, its FK-backed persistence, workspace-scoped GraphQL create/edit mutations, paginated list access, and workspace/id lookup via DataLoader.
Also updated schema generation, frontend GraphQL types, and document usage handling to account for standalone documents.

## Notes
The workspace lookup now uses a batched DataLoader with exact workspace/document matching.