### PR TITLE
feat: add standalone document removal mutation

### DIFF
--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/RemoveStandaloneDocumentMutation.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/RemoveStandaloneDocumentMutation.kt
@@ -1,0 +1,36 @@
+package io.orangebuffalo.simpleaccounting.business.api.standalonedocuments
+
+import com.expediagroup.graphql.generator.annotations.GraphQLDescription
+import com.expediagroup.graphql.server.operations.Mutation
+import io.orangebuffalo.simpleaccounting.business.api.directives.RequiredAuth
+import io.orangebuffalo.simpleaccounting.business.common.exceptions.EntityNotFoundException
+import io.orangebuffalo.simpleaccounting.business.standalonedocuments.StandaloneDocumentsService
+import org.springframework.stereotype.Component
+import org.springframework.validation.annotation.Validated
+
+@Component
+@Validated
+class RemoveStandaloneDocumentMutation(
+    private val standaloneDocumentsService: StandaloneDocumentsService,
+) : Mutation {
+
+    @Suppress("unused")
+    @GraphQLDescription("Removes a standalone document from the specified workspace.")
+    @RequiredAuth(RequiredAuth.AuthType.REGULAR_USER)
+    suspend fun removeStandaloneDocument(
+        @GraphQLDescription("ID of the workspace the standalone document belongs to.")
+        workspaceId: String,
+        @GraphQLDescription("ID of the standalone document to remove.")
+        standaloneDocumentId: String,
+        @GraphQLDescription("Whether to also delete the linked document when it is no longer used. Defaults to true when omitted.")
+        removeDocumentIfUnused: Boolean? = null,
+    ): Boolean {
+        standaloneDocumentsService.removeStandaloneDocument(
+            workspaceId = workspaceId,
+            standaloneDocumentId = standaloneDocumentId,
+            removeDocumentIfUnused = removeDocumentIfUnused ?: true,
+        ) ?: throw EntityNotFoundException("Standalone document $standaloneDocumentId is not found")
+
+        return true
+    }
+}

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/standalonedocuments/StandaloneDocumentsService.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/standalonedocuments/StandaloneDocumentsService.kt
@@ -1,5 +1,6 @@
 package io.orangebuffalo.simpleaccounting.business.standalonedocuments
 
+import io.orangebuffalo.simpleaccounting.business.documents.DocumentIsUsedException
 import io.orangebuffalo.simpleaccounting.business.documents.DocumentsService
 import io.orangebuffalo.simpleaccounting.business.workspaces.WorkspaceAccessMode
 import io.orangebuffalo.simpleaccounting.business.workspaces.WorkspacesService
@@ -27,5 +28,27 @@ class StandaloneDocumentsService(
 
     suspend fun getStandaloneDocumentByIdAndWorkspaceId(id: String, workspaceId: String): StandaloneDocument? = withDbContext {
         standaloneDocumentsRepository.findByIdAndWorkspaceId(id, workspaceId)
+    }
+
+    suspend fun removeStandaloneDocument(
+        workspaceId: String,
+        standaloneDocumentId: String,
+        removeDocumentIfUnused: Boolean,
+    ): StandaloneDocument? {
+        workspacesService.validateWorkspaceAccess(workspaceId, WorkspaceAccessMode.READ_WRITE)
+        val standaloneDocument = getStandaloneDocumentByIdAndWorkspaceId(standaloneDocumentId, workspaceId)
+            ?: return null
+
+        withDbContext { standaloneDocumentsRepository.delete(standaloneDocument) }
+
+        if (removeDocumentIfUnused) {
+            try {
+                documentsService.deleteDocument(workspaceId, standaloneDocument.documentId)
+            } catch (_: DocumentIsUsedException) {
+                // The standalone reference is removed; keep the linked document when another entity still uses it.
+            }
+        }
+
+        return standaloneDocument
     }
 }

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/RemoveStandaloneDocumentMutationTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/RemoveStandaloneDocumentMutationTest.kt
@@ -1,0 +1,254 @@
+package io.orangebuffalo.simpleaccounting.business.api.standalonedocuments
+
+import io.kotest.matchers.shouldBe
+import io.orangebuffalo.simpleaccounting.SaIntegrationTestBase
+import io.orangebuffalo.simpleaccounting.business.documents.Document
+import io.orangebuffalo.simpleaccounting.business.standalonedocuments.StandaloneDocument
+import io.orangebuffalo.simpleaccounting.tests.infra.api.ApiTestClient
+import io.orangebuffalo.simpleaccounting.tests.infra.api.GraphqlClientRequestExecutor
+import io.orangebuffalo.simpleaccounting.tests.infra.api.graphqlRawQuery
+import io.orangebuffalo.simpleaccounting.tests.infra.ui.TestDocumentsStorage
+import io.orangebuffalo.simpleaccounting.tests.infra.utils.MOCK_TIME
+import io.orangebuffalo.simpleaccounting.tests.infra.utils.findSingle
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+private const val REMOVE_STANDALONE_DOCUMENT_MUTATION = "removeStandaloneDocument"
+
+@DisplayName("removeStandaloneDocument mutation")
+class RemoveStandaloneDocumentMutationTest(
+    @Autowired private val client: ApiTestClient,
+    @Autowired private val testDocumentsStorage: TestDocumentsStorage,
+) : SaIntegrationTestBase() {
+
+    private val preconditions by lazyPreconditions {
+        object {
+            val fry = fry()
+            val farnsworth = farnsworth()
+            val zoidberg = zoidberg()
+            val fryWorkspace = workspace(owner = fry)
+            val zoidbergWorkspace = workspace(owner = zoidberg)
+            val workspaceAccessToken = workspaceAccessToken(
+                workspace = fryWorkspace,
+                validTill = MOCK_TIME.plusSeconds(10000),
+            )
+            val deliveryReceipt = document(
+                workspace = fryWorkspace,
+                name = "Delivery to Mars receipt",
+                storageLocation = "delivery-to-mars-receipt",
+            )
+            val standaloneDocument = standaloneDocument(
+                workspace = fryWorkspace,
+                document = deliveryReceipt,
+                title = "Delivery to Mars receipt",
+            )
+            val zoidbergReceipt = document(
+                workspace = zoidbergWorkspace,
+                name = "Zoidberg receipt",
+                storageLocation = "zoidberg-receipt",
+            )
+            val zoidbergStandaloneDocument = standaloneDocument(
+                workspace = zoidbergWorkspace,
+                document = zoidbergReceipt,
+                title = "Claw polish receipt",
+            )
+        }
+    }
+
+    @Nested
+    @DisplayName("Authorization")
+    inner class Authorization {
+
+        @Test
+        fun `should return NOT_AUTHORIZED error for anonymous requests`() {
+            client
+                .removeStandaloneDocumentMutation(
+                    workspaceId = preconditions.fryWorkspace.id!!,
+                    standaloneDocumentId = preconditions.standaloneDocument.id!!,
+                )
+                .fromAnonymous()
+                .executeAndVerifyNotAuthorized(path = REMOVE_STANDALONE_DOCUMENT_MUTATION)
+        }
+
+        @Test
+        fun `should return NOT_AUTHORIZED error for admin user`() {
+            client
+                .removeStandaloneDocumentMutation(
+                    workspaceId = preconditions.fryWorkspace.id!!,
+                    standaloneDocumentId = preconditions.standaloneDocument.id!!,
+                )
+                .from(preconditions.farnsworth)
+                .executeAndVerifyNotAuthorized(path = REMOVE_STANDALONE_DOCUMENT_MUTATION)
+        }
+
+        @Test
+        fun `should return NOT_AUTHORIZED error for workspace access token`() {
+            client
+                .removeStandaloneDocumentMutation(
+                    workspaceId = preconditions.fryWorkspace.id!!,
+                    standaloneDocumentId = preconditions.standaloneDocument.id!!,
+                )
+                .usingSharedWorkspaceToken(preconditions.workspaceAccessToken.token)
+                .executeAndVerifyNotAuthorized(path = REMOVE_STANDALONE_DOCUMENT_MUTATION)
+        }
+    }
+
+    @Nested
+    @DisplayName("Business Flow")
+    inner class BusinessFlow {
+
+        @Test
+        fun `should remove standalone document and linked document by default`() {
+            val testData = preconditions {
+                object {
+                    val document = document(
+                        workspace = preconditions.fryWorkspace,
+                        name = "Slurm supplies receipt",
+                        storageLocation = "slurm-supplies-receipt",
+                    )
+                    val standaloneDocument = standaloneDocument(
+                        workspace = preconditions.fryWorkspace,
+                        document = document,
+                        title = "Slurm supplies receipt",
+                    )
+                }
+            }
+            testDocumentsStorage.mockDocumentContent("slurm-supplies-receipt", "Slurm supplies".toByteArray())
+
+            client
+                .removeStandaloneDocumentMutation(
+                    workspaceId = preconditions.fryWorkspace.id!!,
+                    standaloneDocumentId = testData.standaloneDocument.id!!,
+                )
+                .from(preconditions.fry)
+                .executeAndVerifyResponse(
+                    REMOVE_STANDALONE_DOCUMENT_MUTATION to JsonPrimitive(true)
+                )
+
+            aggregateTemplate.findById(testData.standaloneDocument.id!!, StandaloneDocument::class.java).shouldBe(null)
+            aggregateTemplate.findById(testData.document.id!!, Document::class.java).shouldBe(null)
+            testDocumentsStorage.hasUploadedContent("slurm-supplies-receipt").shouldBe(false)
+        }
+
+        @Test
+        fun `should keep linked document when remove document if unused is false`() {
+            val testData = preconditions {
+                object {
+                    val document = document(
+                        workspace = preconditions.fryWorkspace,
+                        name = "Robot oil receipt",
+                        storageLocation = "robot-oil-receipt",
+                    )
+                    val standaloneDocument = standaloneDocument(
+                        workspace = preconditions.fryWorkspace,
+                        document = document,
+                        title = "Robot oil receipt",
+                    )
+                }
+            }
+            testDocumentsStorage.mockDocumentContent("robot-oil-receipt", "Robot oil".toByteArray())
+
+            client
+                .removeStandaloneDocumentMutation(
+                    workspaceId = preconditions.fryWorkspace.id!!,
+                    standaloneDocumentId = testData.standaloneDocument.id!!,
+                    removeDocumentIfUnused = false,
+                )
+                .from(preconditions.fry)
+                .executeAndVerifyResponse(
+                    REMOVE_STANDALONE_DOCUMENT_MUTATION to JsonPrimitive(true)
+                )
+
+            aggregateTemplate.findById(testData.standaloneDocument.id!!, StandaloneDocument::class.java).shouldBe(null)
+            aggregateTemplate.findSingle<Document>(testData.document.id!!).id.shouldBe(testData.document.id)
+            testDocumentsStorage.hasUploadedContent("robot-oil-receipt").shouldBe(true)
+        }
+
+        @Test
+        fun `should keep linked document when it is still used`() {
+            val testData = preconditions {
+                object {
+                    val document = document(
+                        workspace = preconditions.fryWorkspace,
+                        name = "Planet Express equipment receipt",
+                        storageLocation = "planet-express-equipment-receipt",
+                    ).also { document ->
+                        expense(
+                            workspace = preconditions.fryWorkspace,
+                            title = "Planet Express equipment",
+                            attachments = setOf(document),
+                        )
+                    }
+                    val standaloneDocument = standaloneDocument(
+                        workspace = preconditions.fryWorkspace,
+                        document = document,
+                        title = "Planet Express equipment receipt",
+                    )
+                }
+            }
+            testDocumentsStorage.mockDocumentContent(
+                "planet-express-equipment-receipt",
+                "Planet Express equipment".toByteArray(),
+            )
+
+            client
+                .removeStandaloneDocumentMutation(
+                    workspaceId = preconditions.fryWorkspace.id!!,
+                    standaloneDocumentId = testData.standaloneDocument.id!!,
+                )
+                .from(preconditions.fry)
+                .executeAndVerifyResponse(
+                    REMOVE_STANDALONE_DOCUMENT_MUTATION to JsonPrimitive(true)
+                )
+
+            aggregateTemplate.findById(testData.standaloneDocument.id!!, StandaloneDocument::class.java).shouldBe(null)
+            aggregateTemplate.findSingle<Document>(testData.document.id!!).id.shouldBe(testData.document.id)
+            testDocumentsStorage.hasUploadedContent("planet-express-equipment-receipt").shouldBe(true)
+        }
+
+        @Test
+        fun `should return ENTITY_NOT_FOUND error for non-existent standalone document`() {
+            client
+                .removeStandaloneDocumentMutation(
+                    workspaceId = preconditions.fryWorkspace.id!!,
+                    standaloneDocumentId = "missing-id",
+                )
+                .from(preconditions.fry)
+                .executeAndVerifyEntityNotFoundError(path = REMOVE_STANDALONE_DOCUMENT_MUTATION)
+        }
+
+        @Test
+        fun `should return ENTITY_NOT_FOUND error when workspace belongs to another user`() {
+            client
+                .removeStandaloneDocumentMutation(
+                    workspaceId = preconditions.zoidbergWorkspace.id!!,
+                    standaloneDocumentId = preconditions.zoidbergStandaloneDocument.id!!,
+                )
+                .from(preconditions.fry)
+                .executeAndVerifyEntityNotFoundError(path = REMOVE_STANDALONE_DOCUMENT_MUTATION)
+        }
+    }
+
+    private fun ApiTestClient.removeStandaloneDocumentMutation(
+        workspaceId: String,
+        standaloneDocumentId: String,
+        removeDocumentIfUnused: Boolean? = null,
+    ): GraphqlClientRequestExecutor {
+        val removeDocumentIfUnusedArg = removeDocumentIfUnused
+            ?.let { ", removeDocumentIfUnused: $it" }
+            .orEmpty()
+        return graphqlRawQuery(
+            """
+                mutation {
+                  removeStandaloneDocument(
+                    workspaceId: "$workspaceId",
+                    standaloneDocumentId: "$standaloneDocumentId"$removeDocumentIfUnusedArg
+                  )
+                }
+            """.trimIndent()
+        )
+    }
+}

--- a/app/src/test/resources/api-schema.graphqls
+++ b/app/src/test/resources/api-schema.graphqls
@@ -1016,6 +1016,15 @@ type Mutation {
   invalidateRefreshToken: Boolean! @auth(type : ANONYMOUS)
   "Refreshes the access token using the refresh token from cookies or current authentication. Returns a response with either a valid access token or null if authentication fails."
   refreshAccessToken: RefreshAccessTokenResponse! @auth(type : ANONYMOUS)
+  "Removes a standalone document from the specified workspace."
+  removeStandaloneDocument(
+    "Whether to also delete the linked document when it is no longer used. Defaults to true when omitted."
+    removeDocumentIfUnused: Boolean,
+    "ID of the standalone document to remove."
+    standaloneDocumentId: String!,
+    "ID of the workspace the standalone document belongs to."
+    workspaceId: String!
+  ): Boolean! @auth(type : REGULAR_USER)
   "Saves a shared workspace to the current user's list using an access token."
   saveSharedWorkspace(
     "The workspace access token."

--- a/frontend/src/services/api/gql/schema-types.ts
+++ b/frontend/src/services/api/gql/schema-types.ts
@@ -771,6 +771,8 @@ export type Mutation = {
   invalidateRefreshToken: Scalars['Boolean']['output'];
   /** Refreshes the access token using the refresh token from cookies or current authentication. Returns a response with either a valid access token or null if authentication fails. */
   refreshAccessToken: RefreshAccessTokenResponse;
+  /** Removes a standalone document from the specified workspace. */
+  removeStandaloneDocument: Scalars['Boolean']['output'];
   /** Saves a shared workspace to the current user's list using an access token. */
   saveSharedWorkspace: Workspace;
   /** Updates the current user profile information. */
@@ -1054,6 +1056,13 @@ export type MutationEditUserArgs = {
 export type MutationEditWorkspaceArgs = {
   id: Scalars['String']['input'];
   name: Scalars['String']['input'];
+};
+
+
+export type MutationRemoveStandaloneDocumentArgs = {
+  removeDocumentIfUnused?: InputMaybe<Scalars['Boolean']['input']>;
+  standaloneDocumentId: Scalars['String']['input'];
+  workspaceId: Scalars['String']['input'];
 };
 
 


### PR DESCRIPTION
## Problem statement

Standalone documents could be created and edited, but there was no GraphQL mutation to remove them while correctly handling the linked document lifecycle.

## Solution summary

Added `removeStandaloneDocument` mutation that removes the standalone document, optionally deletes the linked document when it becomes unused, and reuses the existing document deletion flow.
Added integration coverage for authorization, not-found handling, default linked document deletion, and keeping linked documents when requested or still referenced.

## Notes

Validation was completed before invoking this publish workflow, including focused backend mutation tests and regenerated GraphQL schema/types.
