### PR TITLE
feat: Improve document overview actions menu

### DIFF
--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/documents/DocumentsOverviewFullStackTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/documents/DocumentsOverviewFullStackTest.kt
@@ -16,14 +16,12 @@ import io.orangebuffalo.simpleaccounting.business.ui.user.invoices.EditInvoicePa
 import io.orangebuffalo.simpleaccounting.tests.infra.thirdparty.GoogleDriveApiMocks
 import io.orangebuffalo.simpleaccounting.tests.infra.thirdparty.GoogleOAuthMocks
 import io.orangebuffalo.simpleaccounting.tests.infra.ui.TestDocumentsStorage
-import io.orangebuffalo.simpleaccounting.tests.infra.ui.components.SaIcon
 import io.orangebuffalo.simpleaccounting.tests.infra.ui.components.SaOverviewItem.Companion.primaryAttribute
 import io.orangebuffalo.simpleaccounting.tests.infra.ui.components.SaOverviewItemData
 import io.orangebuffalo.simpleaccounting.tests.infra.ui.components.SaIconType
 import io.orangebuffalo.simpleaccounting.tests.infra.ui.components.shouldHaveSideMenu
 import io.orangebuffalo.simpleaccounting.tests.infra.ui.components.shouldHaveTitles
 import io.orangebuffalo.simpleaccounting.tests.infra.utils.MOCK_TIME
-import io.orangebuffalo.simpleaccounting.tests.infra.utils.dataValues
 import io.orangebuffalo.simpleaccounting.tests.infra.utils.downloadBytes
 import io.orangebuffalo.simpleaccounting.tests.infra.utils.findSingle
 import io.orangebuffalo.simpleaccounting.tests.infra.utils.withBlockedGqlApiResponse
@@ -195,6 +193,12 @@ class DocumentsOverviewFullStackTest : SaFullStackTestBase() {
                 }
             }
             reportRendering("documents-overview.loaded")
+
+            pageItems {
+                val unusedDocument = shouldHaveItemSatisfying { it.title == "Unused Receipt.pdf" }
+                unusedDocument.shouldHaveActionMenuItems("Download", "Delete")
+            }
+            reportRenderingWithPopovers("documents-overview.actions-menu")
         }
     }
 
@@ -204,10 +208,7 @@ class DocumentsOverviewFullStackTest : SaFullStackTestBase() {
         *usages,
     )
 
-    private fun lastColumnActions() = dataValues(
-        SaIcon.iconValue(SaIconType.DOWNLOAD),
-        "Download",
-    )
+    private fun lastColumnActions(): String? = null
 
     @Test
     fun `should disable download while document storages status is loading`(page: Page) {
@@ -244,10 +245,6 @@ class DocumentsOverviewFullStackTest : SaFullStackTestBase() {
                             "Download",
                             "Waiting for the storage to become available",
                         )
-                        documentItem.shouldHaveActionMenuDisabled()
-                        documentItem.shouldHaveActionMenuTooltip(
-                            "Waiting for the storage to become available",
-                        )
                     }
                 }
             }
@@ -278,11 +275,6 @@ class DocumentsOverviewFullStackTest : SaFullStackTestBase() {
                 documentItem.shouldHaveLastColumnActionDisabled("Download")
                 documentItem.shouldHaveLastColumnActionTooltip(
                     "Download",
-                    "You need to (re-)activate the documents storage to download this document. " +
-                            "Navigate to your profile settings and check there.",
-                )
-                documentItem.shouldHaveActionMenuDisabled()
-                documentItem.shouldHaveActionMenuTooltip(
                     "You need to (re-)activate the documents storage to download this document. " +
                             "Navigate to your profile settings and check there.",
                 )
@@ -331,7 +323,7 @@ class DocumentsOverviewFullStackTest : SaFullStackTestBase() {
             pageItems {
                 val unusedItem = shouldHaveItemSatisfying { it.title == "Unused Slurm Receipt.pdf" }
                 shouldHaveItemSatisfying { it.title == "Used Robot Oil Receipt.pdf" }
-                    .shouldHaveLastColumnContent("Download")
+                    .shouldHaveActionMenuItems("Download")
                 unusedItem.clickActionMenuItem("Delete")
             }
             confirmDocumentDeletion()

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/documents/DocumentsOverviewPage.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/documents/DocumentsOverviewPage.kt
@@ -6,6 +6,7 @@ import io.orangebuffalo.simpleaccounting.tests.infra.ui.components.ConfirmationD
 import io.orangebuffalo.simpleaccounting.tests.infra.ui.components.PageHeader.Companion.pageHeader
 import io.orangebuffalo.simpleaccounting.tests.infra.ui.components.SaOverviewItem.Companion.overviewItems
 import io.orangebuffalo.simpleaccounting.tests.infra.ui.components.SaPageBase
+import io.orangebuffalo.simpleaccounting.tests.infra.ui.reportRendering
 
 class DocumentsOverviewPage private constructor(page: Page) : SaPageBase(page) {
     private val header = components.pageHeader("Documents")
@@ -20,6 +21,10 @@ class DocumentsOverviewPage private constructor(page: Page) : SaPageBase(page) {
         components.confirmationDialog()
             .shouldBeVisible()
             .clickButton("Delete")
+    }
+
+    fun reportRenderingWithPopovers(name: String) {
+        page.locator("body").reportRendering(name)
     }
 
     companion object {

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/tests/infra/ui/components/SaOverviewItem.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/tests/infra/ui/components/SaOverviewItem.kt
@@ -153,19 +153,23 @@ class SaOverviewItem private constructor(
     }
 
     fun clickLastColumnAction(actionText: String) {
-        lastColumnActionButton(actionText).click()
+        openActionMenu()
+        actionMenuItemButton(actionText).click()
     }
 
     fun shouldHaveLastColumnActionDisabled(actionText: String) {
-        lastColumnActionButton(actionText).shouldBeDisabled()
+        openActionMenu()
+        actionMenuItemButton(actionText).shouldBeDisabled()
     }
 
     fun shouldHaveLastColumnActionEnabled(actionText: String) {
-        lastColumnActionButton(actionText).shouldBeEnabled()
+        openActionMenu()
+        actionMenuItemButton(actionText).shouldBeEnabled()
     }
 
     fun shouldHaveLastColumnActionTooltip(actionText: String, tooltip: String) {
-        val trigger = lastColumnActionTrigger(actionText)
+        openActionMenu()
+        val trigger = actionMenuItemTrigger(actionText)
         trigger.hover()
         trigger.shouldSatisfy {
             val popperId = getAttribute("aria-describedby").shouldNotBeBlank()
@@ -188,32 +192,43 @@ class SaOverviewItem private constructor(
     }
 
     fun openActionMenu() {
+        panel.page().keyboard().press("Escape")
         actionMenuButton().click()
+        actionPopover().shouldBeVisible()
+    }
+
+    fun shouldHaveActionMenuItems(vararg actionTexts: String) {
+        openActionMenu()
+        actionPopover().locator(".documents-overview-panel__action").shouldSatisfy {
+            allInnerTexts().shouldContainExactly(actionTexts.toList())
+        }
     }
 
     fun clickActionMenuItem(actionText: String) {
         openActionMenu()
-        panel.page()
-            .locator(".el-dropdown-menu__item")
-            .filter(Locator.FilterOptions().setHasText(actionText))
-            .click()
+        actionMenuItemButton(actionText).click()
     }
 
     fun shouldHaveLastColumnContent(content: String) {
         panel.locator(".overview-item__last-column").shouldHaveText(content)
     }
 
-    private fun lastColumnActionButton(actionText: String) = panel.locator(".overview-item__last-column")
-        .getByRole(AriaRole.BUTTON, Locator.GetByRoleOptions().setName(actionText).setExact(true))
+    private fun actionMenuItemButton(actionText: String) = actionPopover()
+        .locator("button.documents-overview-panel__action, .documents-overview-panel__action button")
+        .filter(Locator.FilterOptions().setHasText(actionText))
 
-    private fun lastColumnActionTrigger(actionText: String) = lastColumnActionButton(actionText)
+    private fun actionMenuItemTrigger(actionText: String) = actionMenuItemButton(actionText)
         .locator("xpath=ancestor::*[${XPath.hasClass("el-tooltip__trigger")}][1]")
 
-    private fun actionMenuButton() = panel.locator(".overview-item__last-column .el-dropdown .el-button")
+    private fun actionMenuButton() = panel.locator(".overview-item__last-column .documents-overview-panel__actions-trigger")
 
     private fun actionMenuTrigger() = panel.locator(
-        ".overview-item__last-column .el-dropdown .el-tooltip__trigger[aria-haspopup='menu']"
+        ".overview-item__last-column .documents-overview-panel__actions-trigger"
     )
+
+    private fun actionPopover() = panel.page()
+        .locator(".documents-overview-panel__actions-popover:visible")
+        .last()
 
     companion object {
         fun ComponentsAccessors.overviewItems() =

--- a/frontend/src/pages/documents/DocumentsOverviewPanel.vue
+++ b/frontend/src/pages/documents/DocumentsOverviewPanel.vue
@@ -33,21 +33,31 @@
 
     <template #last-column>
       <div class="documents-overview-panel__actions">
-        <SaDocumentDownloadLink
-          :document-id="document.id"
-          :document-name="document.name"
-          :disabled="storageActionDisabled"
-          :disabled-tooltip="storageActionDisabledTooltip"
-          show-icon
-          class="documents-overview-panel__download-link"
-        />
-        <ElDropdown
-          v-if="canDelete"
+        <ElPopover
           trigger="click"
-          @command="handleActionCommand"
+          placement="bottom-end"
+          popper-class="documents-overview-panel__actions-popover"
         >
-          <span>
+          <template #reference>
+            <ElButton
+              link
+              :icon="Menu"
+              :aria-label="$t.documentsOverviewPanel.actions.label()"
+              class="documents-overview-panel__actions-trigger"
+            />
+          </template>
+
+          <div class="documents-overview-panel__actions-menu">
+            <SaDocumentDownloadLink
+              :document-id="document.id"
+              :document-name="document.name"
+              :disabled="storageActionDisabled"
+              :disabled-tooltip="storageActionDisabledTooltip"
+              show-icon
+              class="documents-overview-panel__action"
+            />
             <ElTooltip
+              v-if="canDelete"
               :content="storageActionDisabledTooltip"
               :disabled="!storageActionDisabledTooltip"
               placement="bottom"
@@ -55,31 +65,17 @@
               <span>
                 <ElButton
                   link
-                  :aria-label="$t.documentsOverviewPanel.actions.label()"
+                  :icon="Delete"
                   :disabled="storageActionDisabled || deleting"
+                  class="documents-overview-panel__action documents-overview-panel__danger-action"
+                  @click="deleteDocument"
                 >
-                  <SaIcon icon="menu" />
+                  {{ $t.documentsOverviewPanel.delete.label() }}
                 </ElButton>
               </span>
             </ElTooltip>
-          </span>
-
-          <template #dropdown>
-            <ElDropdownMenu>
-              <ElDropdownItem
-                command="delete"
-                :disabled="deleting"
-                class="documents-overview-panel__danger-action"
-              >
-                <SaIcon
-                  icon="delete"
-                  class="documents-overview-panel__action-icon"
-                />
-                {{ $t.documentsOverviewPanel.delete.label() }}
-              </ElDropdownItem>
-            </ElDropdownMenu>
-          </template>
-        </ElDropdown>
+          </div>
+        </ElPopover>
       </div>
     </template>
   </SaOverviewItem>
@@ -87,8 +83,8 @@
 
 <script lang="ts" setup>
   import { computed, ref } from 'vue';
-  import { ElDropdown, ElDropdownItem, ElDropdownMenu } from 'element-plus';
-  import SaIcon from '@/components/SaIcon.vue';
+  import { ElPopover } from 'element-plus';
+  import { Delete, Menu } from '@element-plus/icons-vue';
   import SaOverviewItem from '@/components/overview-item/SaOverviewItem.vue';
   import SaOverviewItemPrimaryAttribute from '@/components/overview-item/SaOverviewItemPrimaryAttribute.vue';
   import SaDocumentDownloadLink from '@/components/documents/SaDocumentDownloadLink.vue';
@@ -181,12 +177,6 @@
     },
   );
 
-  const handleActionCommand = (command: string) => {
-    if (command === 'delete') {
-      deleteDocument();
-    }
-  };
-
   const storageLabel = computed(() => {
     switch (props.document.storageId) {
     case 'google-drive':
@@ -253,17 +243,34 @@
 
     &__actions {
       display: flex;
-      gap: 12px;
       justify-content: flex-end;
-      flex-wrap: wrap;
-    }
-
-    &__action-icon {
-      margin-right: 4px;
     }
 
     &__danger-action {
       color: var(--el-color-danger);
+    }
+  }
+
+  .documents-overview-panel__actions-popover {
+    width: max-content !important;
+    min-width: 0 !important;
+  }
+
+  .documents-overview-panel__actions-menu {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: stretch;
+    min-width: max-content;
+
+    .documents-overview-panel__action,
+    .sa-document-download-link,
+    .el-button {
+      width: 100%;
+    }
+
+    .el-button {
+      justify-content: flex-start;
+      margin-left: 0;
     }
   }
 </style>

--- a/frontend/src/pages/documents/DocumentsOverviewPanel.vue
+++ b/frontend/src/pages/documents/DocumentsOverviewPanel.vue
@@ -65,6 +65,7 @@
               <span>
                 <ElButton
                   link
+                  type="danger"
                   :icon="Delete"
                   :disabled="storageActionDisabled || deleting"
                   class="documents-overview-panel__action documents-overview-panel__danger-action"
@@ -260,6 +261,7 @@
     display: inline-flex;
     flex-direction: column;
     align-items: stretch;
+    gap: 5px;
     min-width: max-content;
 
     .documents-overview-panel__action,


### PR DESCRIPTION
## Problem statement

Document overview row actions used a separate download action and custom dropdown/menu icons, making the actions less consistent with Element Plus patterns.

## Solution summary

Replaced the custom action menu with an Element Plus popover triggered by a ghost menu icon, moved download into the menu, and styled delete as a danger action with updated full stack render coverage.

## Notes

Validation completed before invoking this publish workflow: frontend typecheck, frontend lint, and the documents overview full stack test class.
