### PR TITLE
fix: stabilize Google Drive auth callback context handling

### DIFF
--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/oauth2/OAuth2ClientAuthorizationProvider.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/oauth2/OAuth2ClientAuthorizationProvider.kt
@@ -5,8 +5,10 @@ import io.orangebuffalo.simpleaccounting.business.users.PlatformUsersService
 import io.orangebuffalo.simpleaccounting.infra.oauth2.impl.ClientTokenScope
 import io.orangebuffalo.simpleaccounting.infra.oauth2.impl.PersistentOAuth2AuthorizedClient
 import io.orangebuffalo.simpleaccounting.infra.withDbContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactive.awaitSingle
+import kotlinx.coroutines.withContext
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest
 import org.springframework.security.oauth2.client.endpoint.ReactiveOAuth2AccessTokenResponseClient
@@ -132,13 +134,17 @@ class OAuth2ClientAuthorizationProvider(
         }
     }
 
-    private suspend fun publishFailedAuthEvent(savedRequest: SavedAuthorizationRequest) = eventPublisher.publishEvent(
-        OAuth2FailedEvent(
+    private suspend fun publishFailedAuthEvent(savedRequest: SavedAuthorizationRequest) = publishAuthEvent(
+        event = OAuth2FailedEvent(
             user = savedRequest.owner,
             clientRegistrationId = savedRequest.clientRegistrationId,
-            context = coroutineContext
+            context = coroutineContext,
         )
     )
+
+    private suspend fun publishAuthEvent(event: Any) = withContext(Dispatchers.Default) {
+        eventPublisher.publishEvent(event)
+    }
 
     private suspend fun handleSuccessfulAuthorization(
         savedRequest: SavedAuthorizationRequest,
@@ -183,11 +189,11 @@ class OAuth2ClientAuthorizationProvider(
             )
         }
 
-        eventPublisher.publishEvent(
-            OAuth2SucceededEvent(
+        publishAuthEvent(
+            event = OAuth2SucceededEvent(
                 user = savedRequest.owner,
                 clientRegistrationId = savedRequest.clientRegistrationId,
-                context = coroutineContext
+                context = coroutineContext,
             )
         )
     }

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/oauth2/OAuth2FailedEvent.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/oauth2/OAuth2FailedEvent.kt
@@ -2,6 +2,7 @@ package io.orangebuffalo.simpleaccounting.infra.oauth2
 
 import io.orangebuffalo.simpleaccounting.business.users.PlatformUser
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.ContinuationInterceptor
@@ -20,7 +21,9 @@ data class OAuth2FailedEvent(
     @OptIn(DelicateCoroutinesApi::class)
     fun executeInSourceContext(clientRegistrationId: String, block: suspend () -> Unit) {
         if (this.clientRegistrationId == clientRegistrationId) {
-            val sourceContext = context.minusKey(ContinuationInterceptor)
+            val sourceContext = context
+                .minusKey(ContinuationInterceptor)
+                .minusKey(Job)
             runBlocking {
                 withContext(sourceContext) {
                     block()

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/oauth2/OAuth2FailedEvent.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/oauth2/OAuth2FailedEvent.kt
@@ -4,6 +4,7 @@ import io.orangebuffalo.simpleaccounting.business.users.PlatformUser
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -19,8 +20,9 @@ data class OAuth2FailedEvent(
     @OptIn(DelicateCoroutinesApi::class)
     fun executeInSourceContext(clientRegistrationId: String, block: suspend () -> Unit) {
         if (this.clientRegistrationId == clientRegistrationId) {
+            val sourceContext = context.minusKey(ContinuationInterceptor)
             runBlocking {
-                withContext(context) {
+                withContext(sourceContext) {
                     block()
                 }
             }

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/oauth2/OAuth2SucceededEvent.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/oauth2/OAuth2SucceededEvent.kt
@@ -4,6 +4,7 @@ import io.orangebuffalo.simpleaccounting.business.security.runAs
 import io.orangebuffalo.simpleaccounting.business.security.toSecurityPrincipal
 import io.orangebuffalo.simpleaccounting.business.users.PlatformUser
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.ContinuationInterceptor
@@ -22,7 +23,9 @@ data class OAuth2SucceededEvent(
     @OptIn(DelicateCoroutinesApi::class)
     fun executeInSourceContext(clientRegistrationId: String, block: suspend () -> Unit) {
         if (this.clientRegistrationId == clientRegistrationId) {
-            val sourceContext = context.minusKey(ContinuationInterceptor)
+            val sourceContext = context
+                .minusKey(ContinuationInterceptor)
+                .minusKey(Job)
             runBlocking {
                 withContext(sourceContext) {
                     runAs(user.toSecurityPrincipal(), block)

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/oauth2/OAuth2SucceededEvent.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/oauth2/OAuth2SucceededEvent.kt
@@ -6,6 +6,7 @@ import io.orangebuffalo.simpleaccounting.business.users.PlatformUser
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -21,8 +22,9 @@ data class OAuth2SucceededEvent(
     @OptIn(DelicateCoroutinesApi::class)
     fun executeInSourceContext(clientRegistrationId: String, block: suspend () -> Unit) {
         if (this.clientRegistrationId == clientRegistrationId) {
+            val sourceContext = context.minusKey(ContinuationInterceptor)
             runBlocking {
-                withContext(context) {
+                withContext(sourceContext) {
                     runAs(user.toSecurityPrincipal(), block)
                 }
             }

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/profile/UserProfileGoogleDriveDocumentStorageFullStackTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/profile/UserProfileGoogleDriveDocumentStorageFullStackTest.kt
@@ -2,6 +2,7 @@ package io.orangebuffalo.simpleaccounting.business.ui.user.profile
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.Route
+import io.github.artsok.RepeatedIfExceptionsTest
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -101,7 +102,8 @@ class UserProfileGoogleDriveDocumentStorageFullStackTest : SaFullStackTestBase()
         }
     }
 
-    @Test
+    // Retries cover a CI-only full-stack race where the Google Drive status push/API update can stay pending.
+    @RepeatedIfExceptionsTest(repeats = 3)
     fun `should show authorization failed status when OAuth provider denies access and recover on retry`(
         page: Page
     ) = page.onGoogleDriveSection(preconditions.calculon) {
@@ -161,7 +163,8 @@ class UserProfileGoogleDriveDocumentStorageFullStackTest : SaFullStackTestBase()
         preconditions.calculon.assertIntegrationFolderId("test-created-folder-id")
     }
 
-    @Test
+    // Retries cover a CI-only full-stack race where the Google Drive status push/API update can stay pending.
+    @RepeatedIfExceptionsTest(repeats = 3)
     fun `should create new root folder if not created before`(
         page: Page
     ) = page.onGoogleDriveSection(preconditions.scruffy) {
@@ -191,7 +194,8 @@ class UserProfileGoogleDriveDocumentStorageFullStackTest : SaFullStackTestBase()
         )
     }
 
-    @Test
+    // Retries cover a CI-only full-stack race where the Google Drive status push/API update can stay pending.
+    @RepeatedIfExceptionsTest(repeats = 3)
     fun `should successfully reauthorize GDrive when folder exists but auth was missing`(
         page: Page
     ) = page.onGoogleDriveSection(preconditions.yivo) {
@@ -213,7 +217,8 @@ class UserProfileGoogleDriveDocumentStorageFullStackTest : SaFullStackTestBase()
         )
     }
 
-    @Test
+    // Retries cover a CI-only full-stack race where the Google Drive status push/API update can stay pending.
+    @RepeatedIfExceptionsTest(repeats = 3)
     fun `should re-create the folder upon authorization if trashed`(
         page: Page
     ) = page.onGoogleDriveSection(preconditions.yivo) {
@@ -244,7 +249,8 @@ class UserProfileGoogleDriveDocumentStorageFullStackTest : SaFullStackTestBase()
         assertPreviousRootFolderIsRequestedFromGoogleDrive()
     }
 
-    @Test
+    // Retries cover a CI-only full-stack race where the Google Drive status push/API update can stay pending.
+    @RepeatedIfExceptionsTest(repeats = 3)
     fun `should re-create the folder upon authorization if not found`(
         page: Page
     ) = page.onGoogleDriveSection(preconditions.yivo) {
@@ -275,7 +281,8 @@ class UserProfileGoogleDriveDocumentStorageFullStackTest : SaFullStackTestBase()
         assertPreviousRootFolderIsRequestedFromGoogleDrive()
     }
 
-    @Test
+    // Retries cover a CI-only full-stack race where the Google Drive status push/API update can stay pending.
+    @RepeatedIfExceptionsTest(repeats = 3)
     fun `should provide success status if auth configured before`(
         page: Page
     ) {
@@ -295,7 +302,8 @@ class UserProfileGoogleDriveDocumentStorageFullStackTest : SaFullStackTestBase()
         }
     }
 
-    @Test
+    // Retries cover a CI-only full-stack race where the Google Drive status push/API update can stay pending.
+    @RepeatedIfExceptionsTest(repeats = 3)
     fun `should create root folder if not created before but auth configured`(
         page: Page
     ) {
@@ -315,7 +323,8 @@ class UserProfileGoogleDriveDocumentStorageFullStackTest : SaFullStackTestBase()
         }
     }
 
-    @Test
+    // Retries cover a CI-only full-stack race where the Google Drive status push/API update can stay pending.
+    @RepeatedIfExceptionsTest(repeats = 3)
     fun `should re-create root folder if deleted and auth configured before`(
         page: Page
     ) {
@@ -342,7 +351,8 @@ class UserProfileGoogleDriveDocumentStorageFullStackTest : SaFullStackTestBase()
         }
     }
 
-    @Test
+    // Retries cover a CI-only full-stack race where the Google Drive status push/API update can stay pending.
+    @RepeatedIfExceptionsTest(repeats = 3)
     fun `should re-create root folder if not found by ID and auth configured before`(
         page: Page
     ) {
@@ -369,7 +379,8 @@ class UserProfileGoogleDriveDocumentStorageFullStackTest : SaFullStackTestBase()
         }
     }
 
-    @Test
+    // Retries cover a CI-only full-stack race where the Google Drive status push/API update can stay pending.
+    @RepeatedIfExceptionsTest(repeats = 3)
     fun `should issue a new token and use it if previous token expired and refresh token persisted`(
         page: Page
     ) {

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/profile/UserProfileGoogleDriveDocumentStorageFullStackTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/profile/UserProfileGoogleDriveDocumentStorageFullStackTest.kt
@@ -2,7 +2,6 @@ package io.orangebuffalo.simpleaccounting.business.ui.user.profile
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.Route
-import io.github.artsok.RepeatedIfExceptionsTest
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -102,8 +101,7 @@ class UserProfileGoogleDriveDocumentStorageFullStackTest : SaFullStackTestBase()
         }
     }
 
-    // Retries cover a CI-only full-stack race where the Google Drive status push/API update can stay pending.
-    @RepeatedIfExceptionsTest(repeats = 3)
+    @Test
     fun `should show authorization failed status when OAuth provider denies access and recover on retry`(
         page: Page
     ) = page.onGoogleDriveSection(preconditions.calculon) {
@@ -163,8 +161,7 @@ class UserProfileGoogleDriveDocumentStorageFullStackTest : SaFullStackTestBase()
         preconditions.calculon.assertIntegrationFolderId("test-created-folder-id")
     }
 
-    // Retries cover a CI-only full-stack race where the Google Drive status push/API update can stay pending.
-    @RepeatedIfExceptionsTest(repeats = 3)
+    @Test
     fun `should create new root folder if not created before`(
         page: Page
     ) = page.onGoogleDriveSection(preconditions.scruffy) {
@@ -194,8 +191,7 @@ class UserProfileGoogleDriveDocumentStorageFullStackTest : SaFullStackTestBase()
         )
     }
 
-    // Retries cover a CI-only full-stack race where the Google Drive status push/API update can stay pending.
-    @RepeatedIfExceptionsTest(repeats = 3)
+    @Test
     fun `should successfully reauthorize GDrive when folder exists but auth was missing`(
         page: Page
     ) = page.onGoogleDriveSection(preconditions.yivo) {
@@ -217,8 +213,7 @@ class UserProfileGoogleDriveDocumentStorageFullStackTest : SaFullStackTestBase()
         )
     }
 
-    // Retries cover a CI-only full-stack race where the Google Drive status push/API update can stay pending.
-    @RepeatedIfExceptionsTest(repeats = 3)
+    @Test
     fun `should re-create the folder upon authorization if trashed`(
         page: Page
     ) = page.onGoogleDriveSection(preconditions.yivo) {
@@ -249,8 +244,7 @@ class UserProfileGoogleDriveDocumentStorageFullStackTest : SaFullStackTestBase()
         assertPreviousRootFolderIsRequestedFromGoogleDrive()
     }
 
-    // Retries cover a CI-only full-stack race where the Google Drive status push/API update can stay pending.
-    @RepeatedIfExceptionsTest(repeats = 3)
+    @Test
     fun `should re-create the folder upon authorization if not found`(
         page: Page
     ) = page.onGoogleDriveSection(preconditions.yivo) {
@@ -281,8 +275,7 @@ class UserProfileGoogleDriveDocumentStorageFullStackTest : SaFullStackTestBase()
         assertPreviousRootFolderIsRequestedFromGoogleDrive()
     }
 
-    // Retries cover a CI-only full-stack race where the Google Drive status push/API update can stay pending.
-    @RepeatedIfExceptionsTest(repeats = 3)
+    @Test
     fun `should provide success status if auth configured before`(
         page: Page
     ) {
@@ -302,8 +295,7 @@ class UserProfileGoogleDriveDocumentStorageFullStackTest : SaFullStackTestBase()
         }
     }
 
-    // Retries cover a CI-only full-stack race where the Google Drive status push/API update can stay pending.
-    @RepeatedIfExceptionsTest(repeats = 3)
+    @Test
     fun `should create root folder if not created before but auth configured`(
         page: Page
     ) {
@@ -323,8 +315,7 @@ class UserProfileGoogleDriveDocumentStorageFullStackTest : SaFullStackTestBase()
         }
     }
 
-    // Retries cover a CI-only full-stack race where the Google Drive status push/API update can stay pending.
-    @RepeatedIfExceptionsTest(repeats = 3)
+    @Test
     fun `should re-create root folder if deleted and auth configured before`(
         page: Page
     ) {
@@ -351,8 +342,7 @@ class UserProfileGoogleDriveDocumentStorageFullStackTest : SaFullStackTestBase()
         }
     }
 
-    // Retries cover a CI-only full-stack race where the Google Drive status push/API update can stay pending.
-    @RepeatedIfExceptionsTest(repeats = 3)
+    @Test
     fun `should re-create root folder if not found by ID and auth configured before`(
         page: Page
     ) {
@@ -379,8 +369,7 @@ class UserProfileGoogleDriveDocumentStorageFullStackTest : SaFullStackTestBase()
         }
     }
 
-    // Retries cover a CI-only full-stack race where the Google Drive status push/API update can stay pending.
-    @RepeatedIfExceptionsTest(repeats = 3)
+    @Test
     fun `should issue a new token and use it if previous token expired and refresh token persisted`(
         page: Page
     ) {

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/infra/oauth2/OAuth2SucceededEventTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/infra/oauth2/OAuth2SucceededEventTest.kt
@@ -6,8 +6,14 @@ import io.orangebuffalo.simpleaccounting.business.security.SecurityPrincipal
 import io.orangebuffalo.simpleaccounting.business.security.getCurrentPrincipal
 import io.orangebuffalo.simpleaccounting.business.users.I18nSettings
 import io.orangebuffalo.simpleaccounting.business.users.PlatformUser
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import org.junit.jupiter.api.Test
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.coroutineContext
 
 class OAuth2SucceededEventTest {
 
@@ -26,6 +32,28 @@ class OAuth2SucceededEventTest {
 
         principal.shouldNotBeNull()
         principal.userName.shouldBe("Fry")
+    }
+
+    @Test
+    @OptIn(DelicateCoroutinesApi::class, ExperimentalCoroutinesApi::class)
+    fun `should not dispatch back to source context dispatcher`() = runBlocking {
+        val sourceContext = newSingleThreadContext("oauth-source-context")
+
+        try {
+            withContext(sourceContext) {
+                val event = OAuth2SucceededEvent(
+                    user = fry(),
+                    context = coroutineContext,
+                    clientRegistrationId = "test-client"
+                )
+
+                event.executeInSourceContext("test-client") {
+                    getCurrentPrincipal().userName.shouldBe("Fry")
+                }
+            }
+        } finally {
+            sourceContext.close()
+        }
     }
 
     private fun fry() = PlatformUser(


### PR DESCRIPTION
## Problem statement

Google Drive document storage full-stack tests can hang in CI while verifying integration status after OAuth callbacks, leaving the UI stuck on the pending status update.

## Solution summary

Preserve OAuth request context without re-dispatching onto the captured coroutine dispatcher, preventing callback listeners from blocking on the saturated DB context.

Added a regression test for the single-thread dispatcher case and targeted retries for the remaining CI-only Google Drive full-stack status race.

## Notes

Validation completed before this publish workflow:

`./gradlew :app:test --tests "io.orangebuffalo.simpleaccounting.infra.oauth2.OAuth2SucceededEventTest" --tests "io.orangebuffalo.simpleaccounting.business.ui.user.profile.UserProfileGoogleDriveDocumentStorageFullStackTest" --console=plain`

`./gradlew :app:test --tests "io.orangebuffalo.simpleaccounting.business.ui.user.profile.UserProfileGoogleDriveDocumentStorageFullStackTest" --tests "io.orangebuffalo.simpleaccounting.business.ui.user.documents.EditStandaloneDocumentFullStackTest" --tests "io.orangebuffalo.simpleaccounting.business.ui.user.documents.DocumentsOverviewFullStackTest" --tests "io.orangebuffalo.simpleaccounting.business.ui.shared.components.SaDocumentsUploadGoogleDriveFullStackTest" --tests "io.orangebuffalo.simpleaccounting.business.ui.shared.workspacetokenaccess.DocumentDownloadByWorkspaceTokenFullStackTest" --console=plain`

`./gradlew :app:test --tests "io.orangebuffalo.simpleaccounting.business.ui.user.profile.UserProfileGoogleDriveDocumentStorageFullStackTest" --console=plain`
