### PR TITLE
tests: lift shared test spies into integration base (#934)

### DIFF
--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/SaIntegrationTestBase.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/SaIntegrationTestBase.kt
@@ -1,6 +1,8 @@
 package io.orangebuffalo.simpleaccounting
 
 import io.orangebuffalo.simpleaccounting.business.documents.storage.local.LocalFileSystemDocumentsStorageProperties
+import io.orangebuffalo.simpleaccounting.business.security.jwt.JwtService
+import io.orangebuffalo.simpleaccounting.business.security.remeberme.RefreshTokensService
 import io.orangebuffalo.simpleaccounting.infra.SimpleAccountingProperties
 import io.orangebuffalo.simpleaccounting.infra.TimeService
 import io.orangebuffalo.simpleaccounting.infra.TokenGenerator
@@ -58,6 +60,12 @@ abstract class SaIntegrationTestBase {
 
     @MockitoSpyBean
     protected lateinit var tokenGenerator: TokenGenerator
+
+    @MockitoSpyBean
+    protected lateinit var jwtService: JwtService
+
+    @MockitoSpyBean
+    protected lateinit var refreshTokensService: RefreshTokensService
 
     @Autowired
     private lateinit var platformTransactionManager: PlatformTransactionManager

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/auth/CreateAccessTokenByCredentialsMutationTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/auth/CreateAccessTokenByCredentialsMutationTest.kt
@@ -1,8 +1,6 @@
 package io.orangebuffalo.simpleaccounting.business.api.auth
 
 import io.orangebuffalo.simpleaccounting.SaIntegrationTestBase
-import io.orangebuffalo.simpleaccounting.business.security.jwt.JwtService
-import io.orangebuffalo.simpleaccounting.business.security.remeberme.RefreshTokensService
 import io.orangebuffalo.simpleaccounting.infra.graphql.DgsConstants
 import io.orangebuffalo.simpleaccounting.infra.graphql.client.MutationProjection
 import io.orangebuffalo.simpleaccounting.tests.infra.api.*
@@ -19,18 +17,10 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.kotlin.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
-import org.springframework.test.context.bean.override.mockito.MockitoBean
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 
 class CreateAccessTokenByCredentialsMutationTest(
     @Autowired private val client: ApiTestClient,
 ) : SaIntegrationTestBase() {
-
-    @MockitoBean
-    lateinit var refreshTokensService: RefreshTokensService
-
-    @MockitoSpyBean
-    lateinit var jwtService: JwtService
 
     private val preconditions by lazyPreconditions {
         object {
@@ -205,7 +195,8 @@ class CreateAccessTokenByCredentialsMutationTest(
             whenever(passwordEncoder.matches("qwerty", preconditions.fry.passwordHash)) doReturn true
 
             runBlocking {
-                whenever(refreshTokensService.generateRefreshToken(preconditions.fry.userName)) doReturn "refreshTokenForFry"
+                doReturn("refreshTokenForFry")
+                    .whenever(refreshTokensService).generateRefreshToken(preconditions.fry.userName)
             }
 
             client

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/auth/CreateAccessTokenByWorkspaceAccessTokenMutationTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/auth/CreateAccessTokenByWorkspaceAccessTokenMutationTest.kt
@@ -2,7 +2,6 @@ package io.orangebuffalo.simpleaccounting.business.api.auth
 
 import io.orangebuffalo.simpleaccounting.SaIntegrationTestBase
 import io.orangebuffalo.simpleaccounting.business.security.SaUserRoles
-import io.orangebuffalo.simpleaccounting.business.security.jwt.JwtService
 import io.orangebuffalo.simpleaccounting.infra.graphql.DgsConstants
 import io.orangebuffalo.simpleaccounting.infra.graphql.client.MutationProjection
 import io.orangebuffalo.simpleaccounting.tests.infra.api.*
@@ -18,15 +17,11 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.kotlin.*
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import java.time.Duration
 
 class CreateAccessTokenByWorkspaceAccessTokenMutationTest(
     @Autowired private val client: ApiTestClient,
 ) : SaIntegrationTestBase() {
-
-    @MockitoSpyBean
-    lateinit var jwtService: JwtService
 
     private val preconditions by lazyPreconditions {
         object {

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/auth/RefreshAccessTokenMutationTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/auth/RefreshAccessTokenMutationTest.kt
@@ -2,8 +2,6 @@ package io.orangebuffalo.simpleaccounting.business.api.auth
 
 import io.orangebuffalo.simpleaccounting.SaIntegrationTestBase
 import io.orangebuffalo.simpleaccounting.business.security.createTransientUserPrincipal
-import io.orangebuffalo.simpleaccounting.business.security.jwt.JwtService
-import io.orangebuffalo.simpleaccounting.business.security.remeberme.RefreshTokensService
 import io.orangebuffalo.simpleaccounting.business.security.toSecurityPrincipal
 import io.orangebuffalo.simpleaccounting.infra.graphql.DgsConstants
 import io.orangebuffalo.simpleaccounting.infra.graphql.client.MutationProjection
@@ -18,18 +16,11 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.*
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.time.Duration
 
 class RefreshAccessTokenMutationTest(
     @Autowired private val client: ApiTestClient,
 ) : SaIntegrationTestBase() {
-
-    @MockitoBean
-    lateinit var jwtService: JwtService
-
-    @MockitoBean
-    lateinit var refreshTokensService: RefreshTokensService
 
     private val preconditions by lazyPreconditions {
         object {
@@ -76,8 +67,9 @@ class RefreshAccessTokenMutationTest(
         suspend fun `should return JWT token when token endpoint is hit and cookie is valid`() {
             val principal = preconditions.fry.toSecurityPrincipal()
 
-            whenever(jwtService.buildJwtToken(principal)) doReturn "jwtTokenForFry"
-            whenever(refreshTokensService.validateTokenAndBuildUserDetails("refreshTokenForFry")) doReturn principal
+            doReturn("jwtTokenForFry").whenever(jwtService).buildJwtToken(principal)
+            doReturn(principal)
+                .whenever(refreshTokensService).validateTokenAndBuildUserDetails("refreshTokenForFry")
 
             client
                 .graphqlMutation { refreshAccessTokenMutation() }
@@ -94,8 +86,9 @@ class RefreshAccessTokenMutationTest(
         suspend fun `should return JWT token when token endpoint is hit and cookie is valid for admin user`() {
             val principal = preconditions.farnsworth.toSecurityPrincipal()
 
-            whenever(jwtService.buildJwtToken(principal)) doReturn "jwtTokenForFarnsworth"
-            whenever(refreshTokensService.validateTokenAndBuildUserDetails("refreshTokenForFarnsworth")) doReturn principal
+            doReturn("jwtTokenForFarnsworth").whenever(jwtService).buildJwtToken(principal)
+            doReturn(principal)
+                .whenever(refreshTokensService).validateTokenAndBuildUserDetails("refreshTokenForFarnsworth")
 
             client
                 .graphqlMutation { refreshAccessTokenMutation() }
@@ -112,7 +105,7 @@ class RefreshAccessTokenMutationTest(
         suspend fun `should return JWT token when user is authenticated with regular user`() {
             val principal = preconditions.fry.toSecurityPrincipal()
 
-            whenever(jwtService.buildJwtToken(principal)) doReturn "jwtTokenForFry"
+            doReturn("jwtTokenForFry").whenever(jwtService).buildJwtToken(principal)
 
             client
                 .graphqlMutation { refreshAccessTokenMutation() }
@@ -128,7 +121,7 @@ class RefreshAccessTokenMutationTest(
         suspend fun `should return JWT token when user is authenticated with admin user`() {
             val principal = preconditions.farnsworth.toSecurityPrincipal()
 
-            whenever(jwtService.buildJwtToken(principal)) doReturn "jwtTokenForFarnsworth"
+            doReturn("jwtTokenForFarnsworth").whenever(jwtService).buildJwtToken(principal)
 
             client
                 .graphqlMutation { refreshAccessTokenMutation() }
@@ -147,12 +140,12 @@ class RefreshAccessTokenMutationTest(
             val validTill = preconditions.validAccessToken.validTill
 
             // Mock JWT validation for the valid token
-            whenever(jwtService.validateTokenAndBuildUserDetails(any())) doReturn
-                    createTransientUserPrincipal(tokenValue)
+            doReturn(createTransientUserPrincipal(tokenValue))
+                .whenever(jwtService).validateTokenAndBuildUserDetails(any())
 
-            whenever(jwtService.buildJwtToken(argThat {
+            doReturn("jwtTokenForTransientUser").whenever(jwtService).buildJwtToken(argThat {
                 userName == "validToken" && isTransient
-            }, eq(validTill))) doReturn "jwtTokenForTransientUser"
+            }, eq(validTill))
 
             client
                 .graphqlMutation { refreshAccessTokenMutation() }
@@ -170,8 +163,8 @@ class RefreshAccessTokenMutationTest(
             val tokenValue = preconditions.revokedAccessToken.token
 
             // Mock JWT validation for the revoked token
-            whenever(jwtService.validateTokenAndBuildUserDetails(any())) doReturn
-                    createTransientUserPrincipal(tokenValue)
+            doReturn(createTransientUserPrincipal(tokenValue))
+                .whenever(jwtService).validateTokenAndBuildUserDetails(any())
 
             client
                 .graphqlMutation { refreshAccessTokenMutation() }
@@ -189,8 +182,8 @@ class RefreshAccessTokenMutationTest(
             val tokenValue = preconditions.expiredAccessToken.token
 
             // Mock JWT validation for the expired token
-            whenever(jwtService.validateTokenAndBuildUserDetails(any())) doReturn
-                    createTransientUserPrincipal(tokenValue)
+            doReturn(createTransientUserPrincipal(tokenValue))
+                .whenever(jwtService).validateTokenAndBuildUserDetails(any())
 
             client
                 .graphqlMutation { refreshAccessTokenMutation() }

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/pushnotifications/PushNotificationsSubscriptionTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/pushnotifications/PushNotificationsSubscriptionTest.kt
@@ -6,7 +6,6 @@ import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
 import io.orangebuffalo.simpleaccounting.SaIntegrationTestBase
 import io.orangebuffalo.simpleaccounting.business.integration.pushnotifications.PushNotificationService
-import io.orangebuffalo.simpleaccounting.business.security.jwt.JwtService
 import io.orangebuffalo.simpleaccounting.business.security.toSecurityPrincipal
 import io.orangebuffalo.simpleaccounting.business.users.PlatformUser
 import kotlinx.coroutines.runBlocking
@@ -32,7 +31,6 @@ import java.util.concurrent.atomic.AtomicLong
 @DisplayName("Push Notifications Subscription")
 class PushNotificationsSubscriptionTest(
     @Autowired private val pushNotificationService: PushNotificationService,
-    @Autowired private val jwtService: JwtService,
     @Autowired private val environment: Environment,
     @Autowired private val objectMapper: ObjectMapper,
 ) : SaIntegrationTestBase() {

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/security/jwt/RefreshTokensServiceTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/security/jwt/RefreshTokensServiceTest.kt
@@ -2,7 +2,6 @@ package io.orangebuffalo.simpleaccounting.business.security.jwt
 
 import io.orangebuffalo.simpleaccounting.business.security.remeberme.RefreshToken
 import io.orangebuffalo.simpleaccounting.business.security.remeberme.RefreshTokensRepository
-import io.orangebuffalo.simpleaccounting.business.security.remeberme.RefreshTokensService
 import io.orangebuffalo.simpleaccounting.SaIntegrationTestBase
 import io.orangebuffalo.simpleaccounting.tests.infra.utils.MOCK_TIME
 import kotlinx.coroutines.runBlocking
@@ -21,7 +20,6 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 
 class RefreshTokensServiceTest(
-    @Autowired private val refreshTokensService: RefreshTokensService,
     @Autowired private val refreshTokensRepository: RefreshTokensRepository,
 ) : SaIntegrationTestBase() {
 

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/SaFullStackTestBase.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/SaFullStackTestBase.kt
@@ -3,7 +3,6 @@ package io.orangebuffalo.simpleaccounting.business.ui
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.options.Cookie
 import io.orangebuffalo.simpleaccounting.SaIntegrationTestBase
-import io.orangebuffalo.simpleaccounting.business.documents.storage.local.LocalFileSystemDocumentsStorageProperties
 import io.orangebuffalo.simpleaccounting.business.security.remeberme.RefreshToken
 import io.orangebuffalo.simpleaccounting.business.users.PlatformUser
 import io.orangebuffalo.simpleaccounting.tests.infra.thirdparty.ThirdPartyApisMocksContextInitializer
@@ -18,7 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.TestExecutionListeners
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import java.time.Instant
 
 /**

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/UiInfrastructureFullStackTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/UiInfrastructureFullStackTest.kt
@@ -1,19 +1,15 @@
 package io.orangebuffalo.simpleaccounting.business.ui
 
 import com.microsoft.playwright.Page
-import io.orangebuffalo.simpleaccounting.business.security.jwt.JwtService
 import io.orangebuffalo.simpleaccounting.business.security.remeberme.RefreshToken
 import io.orangebuffalo.simpleaccounting.business.ui.shared.login.LoginPage.Companion.openLoginPage
 import io.orangebuffalo.simpleaccounting.business.ui.shared.login.LoginPage.Companion.shouldBeLoginPage
 import io.orangebuffalo.simpleaccounting.business.ui.user.dashboard.DashboardPage.Companion.shouldBeDashboardPage
 import io.orangebuffalo.simpleaccounting.tests.infra.ui.components.shouldHaveSideMenu
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.jdbc.core.deleteAll
 
-class UiInfrastructureFullStackTest(
-    @Autowired private val jwtService: JwtService,
-) : SaFullStackTestBase() {
+class UiInfrastructureFullStackTest : SaFullStackTestBase() {
 
     @Test
     fun `should redirect to login page when auth expired`(page: Page) {

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/shared/accountactivation/AccountActivationFullStackTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/shared/accountactivation/AccountActivationFullStackTest.kt
@@ -9,19 +9,15 @@ import io.orangebuffalo.simpleaccounting.business.ui.shared.accountactivation.Ac
 import io.orangebuffalo.simpleaccounting.business.ui.shared.login.LoginPage.Companion.shouldBeLoginPage
 import io.orangebuffalo.simpleaccounting.business.ui.user.accountsetup.AccountSetupPage.Companion.shouldBeAccountSetupPage
 import io.orangebuffalo.simpleaccounting.business.users.PlatformUser
-import io.orangebuffalo.simpleaccounting.infra.TimeService
 import io.orangebuffalo.simpleaccounting.tests.infra.utils.findSingle
 import io.orangebuffalo.simpleaccounting.tests.infra.utils.shouldHaveNotifications
 import io.orangebuffalo.simpleaccounting.tests.infra.utils.withHint
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.whenever
-import org.springframework.beans.factory.annotation.Autowired
 import java.time.Instant
 
-class AccountActivationFullStackTest(
-    @Autowired private val timeServiceSpy: TimeService,
-) : SaFullStackTestBase() {
+class AccountActivationFullStackTest : SaFullStackTestBase() {
     private val preconditions by lazyPreconditions {
         object {
             val user = platformUser(
@@ -34,7 +30,7 @@ class AccountActivationFullStackTest(
             )
 
             init {
-                doReturn(token.expiresAt).whenever(timeServiceSpy).currentTime()
+                doReturn(token.expiresAt).whenever(timeService).currentTime()
             }
         }
     }
@@ -60,7 +56,7 @@ class AccountActivationFullStackTest(
             loginButton { shouldBeHidden() }
 
             // now, token is expired - to simulate token expiration during activation
-            doReturn(preconditions.token.expiresAt.plusSeconds(1)).whenever(timeServiceSpy).currentTime()
+            doReturn(preconditions.token.expiresAt.plusSeconds(1)).whenever(timeService).currentTime()
 
             form {
                 newPassword {
@@ -166,7 +162,7 @@ class AccountActivationFullStackTest(
         }
 
         // reset time to generate valid JWT token on login
-        doReturn(Instant.now()).whenever(timeServiceSpy).currentTime()
+        doReturn(Instant.now()).whenever(timeService).currentTime()
 
         withHint("Should update database with activated user") {
             aggregateTemplate.findSingle<PlatformUser>().should {


### PR DESCRIPTION
## Problem statement

Integration and full-stack tests were declaring their own `TimeService` mocks and a few related auth service mocks, which caused extra Spring test contexts and slowed test execution.

## Solution summary

Lifted shared test doubles into `SaIntegrationTestBase` by reusing shared spy beans for `TimeService`, `JwtService`, and `RefreshTokensService`, and updated affected tests to use the inherited spies instead of per-class declarations.

## Notes

Validation was completed before this publish workflow by running focused `:app:test` coverage for the affected tests.
