### PR TITLE
fix(frontend): split Sass imports correctly (#112)

### DIFF
--- a/frontend/src/pages/settings/workspaces/WorkspacesOverviewItemPanel.vue
+++ b/frontend/src/pages/settings/workspaces/WorkspacesOverviewItemPanel.vue
@@ -171,7 +171,7 @@
 </script>
 
 <style lang="scss">
-  @use "@/styles/main.scss" as *;
+  @use "@/styles/mixins.scss" as *;
   @use "@/styles/vars.scss" as *;
 
   .workspace-panel {
@@ -180,7 +180,7 @@
     margin-bottom: 10px;
 
     &__info-panel {
-      @extend .sa-item-info-panel;
+      @include item-info-panel;
       border-radius: 2px 1px 1px 2px;
       flex-grow: 1;
 

--- a/frontend/src/styles/main.scss
+++ b/frontend/src/styles/main.scss
@@ -77,73 +77,7 @@ textarea {
 }
 
 .sa-item-info-panel {
-  padding: 20px;
-  border: 1px solid $secondary-grey;
-  background-color: $white;
-  border-radius: 2px;
-  overflow: hidden;
-
-  .sa-item-title-panel {
-    display: flex;
-    justify-content: space-between;
-
-    h3 {
-      margin: 0;
-    }
-
-    .sa-item-edit-link {
-      color: $components-color;
-      display: flex;
-      align-items: center;
-
-      .sa-icon {
-        margin-right: 3px;
-        max-height: 13px;
-        max-width: 13px;
-      }
-
-      .el-button {
-        padding: 0;
-        height: auto;
-      }
-    }
-  }
-
-  .sa-item-attributes {
-
-    .sa-item-attribute {
-      display: inline-flex;
-      align-items: center;
-      margin-right: 30px;
-      margin-top: 15px;
-
-      .sa-icon {
-        margin-right: 5px;
-        width: 18px;
-        height: 18px;
-      }
-
-      .sa-secondary-text {
-        margin-left: 5px;
-      }
-
-      .sa-clickable {
-        cursor: pointer;
-      }
-    }
-  }
-
-  .sa-item-section {
-    margin-top: 20px;
-
-    h4 {
-      margin: 0;
-    }
-
-    .sa-item-additional-info {
-      font-style: italic;
-    }
-  }
+  @include item-info-panel;
 }
 
 a {
@@ -157,4 +91,13 @@ a {
 
 .text-right {
   text-align: right;
+}
+
+@keyframes loading-placeholder-animation {
+  0% {
+    background-position: 100% 0
+  }
+  100% {
+    background-position: -100% 0
+  }
 }

--- a/frontend/src/styles/mixins.scss
+++ b/frontend/src/styles/mixins.scss
@@ -50,11 +50,71 @@ $breakpoints: (
   animation: loading-placeholder-animation 1.2s linear infinite;
 }
 
-@keyframes loading-placeholder-animation {
-  0% {
-    background-position: 100% 0
+@mixin item-info-panel() {
+  padding: 20px;
+  border: 1px solid $secondary-grey;
+  background-color: $white;
+  border-radius: 2px;
+  overflow: hidden;
+
+  .sa-item-title-panel {
+    display: flex;
+    justify-content: space-between;
+
+    h3 {
+      margin: 0;
+    }
+
+    .sa-item-edit-link {
+      color: $components-color;
+      display: flex;
+      align-items: center;
+
+      .sa-icon {
+        margin-right: 3px;
+        max-height: 13px;
+        max-width: 13px;
+      }
+
+      .el-button {
+        padding: 0;
+        height: auto;
+      }
+    }
   }
-  100% {
-    background-position: -100% 0
+
+  .sa-item-attributes {
+    .sa-item-attribute {
+      display: inline-flex;
+      align-items: center;
+      margin-right: 30px;
+      margin-top: 15px;
+
+      .sa-icon {
+        margin-right: 5px;
+        width: 18px;
+        height: 18px;
+      }
+
+      .sa-secondary-text {
+        margin-left: 5px;
+      }
+
+      .sa-clickable {
+        cursor: pointer;
+      }
+    }
+  }
+
+  .sa-item-section {
+    margin-top: 20px;
+
+    h4 {
+      margin: 0;
+    }
+
+    .sa-item-additional-info {
+      font-style: italic;
+    }
   }
 }


### PR DESCRIPTION
## Problem statement

Some Sass files were being re-included in component styles, which inflated the generated CSS and added unnecessary Sass compilation work.

## Solution summary

Stop importing the global `main.scss` stylesheet from `WorkspacesOverviewItemPanel.vue`, extract the reusable item info panel styles into a mixin, and keep the loading placeholder keyframes in the global stylesheet so component-level mixin imports do not emit duplicate CSS.

## Notes

Validation was completed before this publish workflow with `./gradlew :frontend:buildFrontend --console=plain`.
