### PR TITLE
fix(frontend): debounce overview search requests

### DIFF
--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/shared/components/SaPageableItemsFullStackTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/shared/components/SaPageableItemsFullStackTest.kt
@@ -1,0 +1,65 @@
+package io.orangebuffalo.simpleaccounting.business.ui.shared.components
+
+import com.microsoft.playwright.Page
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.comparables.shouldBeLessThan
+import io.orangebuffalo.simpleaccounting.business.ui.SaFullStackTestBase
+import io.orangebuffalo.simpleaccounting.business.ui.user.expenses.ExpensesOverviewPage.Companion.openExpensesOverviewPage
+import io.orangebuffalo.simpleaccounting.tests.infra.ui.components.shouldHaveTitles
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class SaPageableItemsFullStackTest : SaFullStackTestBase() {
+
+    @Test
+    fun `should debounce search argument changes and use the final typed query`(page: Page) {
+        val searchQuery = "Robot oil B"
+        val testData = preconditions {
+            object {
+                val fry = fry().also {
+                    val workspace = workspace(owner = it).also { workspace ->
+                        val category = category(workspace = workspace, name = "Robot maintenance")
+                        expense(
+                            workspace = workspace,
+                            category = category,
+                            title = "Robot oil A",
+                            datePaid = LocalDate.of(3025, 6, 5),
+                        )
+                        expense(
+                            workspace = workspace,
+                            category = category,
+                            title = searchQuery,
+                            datePaid = LocalDate.of(3025, 6, 6),
+                        )
+                    }
+                }
+            }
+        }
+        var pageRequests = 0
+        page.onRequest { request ->
+            val postData = try { request.postData() } catch (e: Exception) { null }
+            if (postData?.contains("\"operationName\":\"expensesPage\"") == true) {
+                pageRequests += 1
+            }
+        }
+
+        page.authenticateViaCookie(testData.fry)
+        page.openExpensesOverviewPage {
+            pageItems {
+                shouldHaveDataSatisfying { items ->
+                    items.map { it.title }.shouldContainAll("Robot oil A", searchQuery)
+                }
+            }
+            pageRequests = 0
+
+            filterInput { typeText(searchQuery) }
+            pageItems {
+                shouldHaveTitles(searchQuery)
+            }
+        }
+
+        // We intentionally do not assert an exact count: framework internals may legitimately trigger
+        // one extra query, but debounce must still prevent one API request per typed character.
+        pageRequests.shouldBeLessThan(searchQuery.length)
+    }
+}

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/tests/infra/ui/components/TextInput.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/tests/infra/ui/components/TextInput.kt
@@ -14,6 +14,11 @@ class TextInput private constructor(
     private val input = rootLocator.locator("input, textarea").first()
     fun fill(text: String) = input.fill(text)
 
+    fun typeText(text: String) {
+        input.fill("")
+        input.pressSequentially(text, Locator.PressSequentiallyOptions().setDelay(50.0))
+    }
+
     fun shouldBeVisible() = input.shouldBeVisible()
 
     fun shouldBeHidden() = input.shouldBeHidden()

--- a/frontend/src/components/pageable-items/SaPageableItems.vue
+++ b/frontend/src/components/pageable-items/SaPageableItems.vue
@@ -2,7 +2,8 @@
   <div class="sa-pageable-items">
     <ElPagination
       v-if="paginatorVisible"
-      :current-page="pageNumber"
+      :key="`top-${pageNumber}`"
+      v-model:current-page="pageNumber"
       :page-size="pageSize"
       layout="prev, slot, next"
       :total="totalElements"
@@ -52,7 +53,8 @@
 
     <ElPagination
       v-if="paginatorVisible"
-      :current-page="pageNumber"
+      :key="`bottom-${pageNumber}`"
+      v-model:current-page="pageNumber"
       :page-size="pageSize"
       layout="prev, slot, next"
       :total="totalElements"

--- a/frontend/src/components/pageable-items/SaPageableItems.vue
+++ b/frontend/src/components/pageable-items/SaPageableItems.vue
@@ -2,10 +2,11 @@
   <div class="sa-pageable-items">
     <ElPagination
       v-if="paginatorVisible"
-      v-model:current-page="pageNumber"
+      :current-page="pageNumber"
       :page-size="pageSize"
       layout="prev, slot, next"
       :total="totalElements"
+      @current-change="onPageNumberChange"
     >
       <span class="sa-pageable-items__page-indicator">
         {{ $t.saPageableItems.pageIndicator(pageNumber, totalPages) }}
@@ -51,10 +52,11 @@
 
     <ElPagination
       v-if="paginatorVisible"
-      v-model:current-page="pageNumber"
+      :current-page="pageNumber"
       :page-size="pageSize"
       layout="prev, slot, next"
       :total="totalElements"
+      @current-change="onPageNumberChange"
     >
       <span class="sa-pageable-items__page-indicator">
         {{ $t.saPageableItems.pageIndicator(pageNumber, totalPages) }}
@@ -69,14 +71,16 @@
   generic="TResponse, TPath extends string, TVariables extends PageVars = PageVars"
 >
   import {
-    computed, ref, shallowRef, watch,
+    computed, onBeforeUnmount, ref, shallowRef, watch,
   } from 'vue';
-  import { throttle } from 'lodash';
+  import { debounce, throttle } from 'lodash';
   import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
   import SaIcon from '@/components/SaIcon.vue';
   import { $t } from '@/services/i18n';
   import { useLazyQuery } from '@/services/api/use-gql-api';
   import { useFragment } from '@/services/api/gql/fragment-masking';
+  import { useRequestConfig, type RequestConfigReturn } from '@/services/api';
+  import { ApiRequestCancelledError } from '@/services/api/api-errors.ts';
   import {
     PaginationPageInfoFragment,
     type GqlConnection,
@@ -134,6 +138,7 @@
   const totalElements = ref(0);
   const pageSize = ref(10);
   const data = shallowRef<TNode[]>([]);
+  const searchDebounceMs = 500;
 
   const {
     loading,
@@ -155,8 +160,15 @@
   // Stores the endCursor from each visited page for backward navigation.
   // endCursors[0] = endCursor of page 1, endCursors[1] = endCursor of page 2, etc.
   let endCursors: string[] = [];
+  let requestConfigData: RequestConfigReturn | undefined;
+  let latestLoadId = 0;
 
-  const reloadData = throttle(async () => {
+  const loadData = async () => {
+    latestLoadId += 1;
+    const loadId = latestLoadId;
+    requestConfigData?.cancelRequest();
+    const currentRequestConfig = useRequestConfig({});
+    requestConfigData = currentRequestConfig;
     startLoading();
 
     const after = pageNumber.value === 1
@@ -168,7 +180,13 @@
         ...props.pageQueryArguments,
         first: pageSize.value,
         after,
-      } as TVariables);
+      } as TVariables, {
+        requestConfig: currentRequestConfig.requestConfig,
+      });
+
+      if (loadId !== latestLoadId) {
+        return;
+      }
 
       let connectionValue: unknown = queryResult;
       for (const key of subPath) {
@@ -183,29 +201,46 @@
       if (pageInfo.endCursor) {
         endCursors[pageNumber.value - 1] = pageInfo.endCursor;
       }
-
-      stopLoading();
     } catch (e) {
-      stopLoading();
+      if (e instanceof ApiRequestCancelledError) {
+        return;
+      }
       throw e;
+    } finally {
+      if (requestConfigData === currentRequestConfig) {
+        requestConfigData = undefined;
+      }
+      stopLoading();
     }
-  }, 300, {
-    trailing: true,
-    leading: false,
-  });
+  };
+
+  const reloadData = () => {
+    void loadData();
+  };
+
+  const scheduleReloadData = debounce(reloadData, searchDebounceMs);
+
+  const onPageNumberChange = (newPageNumber: number) => {
+    scheduleReloadData.cancel();
+    pageNumber.value = newPageNumber;
+    reloadData();
+  };
 
   watch(() => props.pageQueryArguments, () => {
+    latestLoadId += 1;
+    requestConfigData?.cancelRequest();
     endCursors = [];
     pageNumber.value = 1;
-    reloadData();
+    scheduleReloadData();
   }, {
     deep: true,
   });
 
-  watch(pageNumber, () => {
-    reloadData();
-  }, {
-    immediate: true,
+  reloadData();
+
+  onBeforeUnmount(() => {
+    scheduleReloadData.cancel();
+    requestConfigData?.cancelRequest();
   });
 
   const paginatorVisible = computed(() => totalElements.value > 0 && !loading.value);


### PR DESCRIPTION
## Problem statement

Overview page search triggered immediate reloads on every input change, without the debounce and request cancellation behavior already used by `SaEntitySelect`.

## Solution summary

Apply debounced, cancellable search reloads generically in `SaPageableItems`, separate search-driven reloads from pagination-driven reloads, and move generic debounce coverage into a dedicated `SaPageableItemsFullStackTest` while keeping the expenses overview test focused on page wiring.

## Notes

Validation was completed before this publish workflow: `:frontend:lint`, `SaPageableItemsFullStackTest`, and expenses overview pagination/filtering full-stack tests.
