### PR TITLE
feat(categories): add filters to pageable API

### DIFF
--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/categories/CategoryGqlDto.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/categories/CategoryGqlDto.kt
@@ -23,6 +23,13 @@ data class CategoryGqlDto(
     val expense: Boolean,
 )
 
+@GraphQLName("CategoryType")
+@GraphQLDescription("Category usage type.")
+enum class CategoryTypeGqlDto {
+    INCOME,
+    EXPENSE,
+}
+
 fun Category.toCategoryGqlDto() = CategoryGqlDto(
     id = id!!,
     name = name,

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/workspaces/WorkspaceGqlDto.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/workspaces/WorkspaceGqlDto.kt
@@ -5,6 +5,7 @@ import com.expediagroup.graphql.generator.annotations.GraphQLName
 import graphql.schema.DataFetchingEnvironment
 import io.orangebuffalo.simpleaccounting.business.api.analytics.AnalyticsGqlDto
 import io.orangebuffalo.simpleaccounting.business.api.categories.CategoryGqlDto
+import io.orangebuffalo.simpleaccounting.business.api.categories.CategoryTypeGqlDto
 import io.orangebuffalo.simpleaccounting.business.api.categories.loadCategoryByWorkspaceAndId
 import io.orangebuffalo.simpleaccounting.business.api.customers.CustomerGqlDto
 import io.orangebuffalo.simpleaccounting.business.api.customers.loadCustomerByWorkspaceAndId
@@ -34,6 +35,7 @@ import io.orangebuffalo.simpleaccounting.services.persistence.model.Tables
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import org.jooq.DSLContext
+import org.jooq.impl.DSL
 import java.util.concurrent.CompletableFuture
 
 @GraphQLName("Workspace")
@@ -58,12 +60,31 @@ data class WorkspaceGqlDto(
         @Max(GraphqlPaginationConstants.PAGE_SIZE_MAX)
         first: Int,
         @GraphQLDescription("Cursor after which to return items.") after: String? = null,
+        @GraphQLDescription("Optional free text search to filter categories by name.")
+        freeSearchText: String? = null,
+        @GraphQLDescription("Optional filter to include categories matching any of the specified usage types.")
+        typeIn: List<CategoryTypeGqlDto>? = null,
         env: DataFetchingEnvironment,
     ): ConnectionGqlDto<CategoryGqlDto> {
         val categoryTable = Tables.CATEGORY
         return env.graphQlContext.getBean<GraphqlPaginationService>()
             .forTable(categoryTable)
             .addPredicate(categoryTable.workspaceId.eq(id))
+            .also {
+                if (freeSearchText != null) {
+                    it.addPredicate(categoryTable.name.containsIgnoreCase(freeSearchText))
+                }
+                if (!typeIn.isNullOrEmpty()) {
+                    it.addPredicate(
+                        DSL.or(typeIn.map { type ->
+                            when (type) {
+                                CategoryTypeGqlDto.INCOME -> categoryTable.income.isTrue
+                                CategoryTypeGqlDto.EXPENSE -> categoryTable.expense.isTrue
+                            }
+                        })
+                    )
+                }
+            }
             .page(first, after) { record ->
                 CategoryGqlDto(
                     id = record[categoryTable.id]!!,

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/categories/CategoriesQueryTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/categories/CategoriesQueryTest.kt
@@ -4,6 +4,7 @@ import io.orangebuffalo.simpleaccounting.SaIntegrationTestBase
 import io.orangebuffalo.simpleaccounting.infra.graphql.connections.encodeCursor
 import io.orangebuffalo.simpleaccounting.tests.infra.api.ApiTestClient
 import io.orangebuffalo.simpleaccounting.tests.infra.api.graphql
+import io.orangebuffalo.simpleaccounting.tests.infra.api.graphqlRawQuery
 import io.orangebuffalo.simpleaccounting.tests.infra.database.EntitiesFactory
 import io.orangebuffalo.simpleaccounting.tests.infra.utils.MOCK_TIME
 import kotlinx.serialization.json.JsonElement
@@ -356,7 +357,175 @@ class CategoriesQueryTest(
                 )
         }
     }
+
+    @Nested
+    @DisplayName("Filtering")
+    inner class Filtering {
+
+        private fun EntitiesFactory.categoriesForFiltering() = object {
+            val fry = fry()
+            val workspace = workspace(owner = fry)
+        }.also {
+            category(
+                workspace = it.workspace,
+                name = "Delivery income",
+                income = true,
+                expense = false,
+                createdAt = MOCK_TIME.plusSeconds(100),
+            )
+            category(
+                workspace = it.workspace,
+                name = "Delivery expense",
+                income = false,
+                expense = true,
+                createdAt = MOCK_TIME.plusSeconds(200),
+            )
+            category(
+                workspace = it.workspace,
+                name = "Robot maintenance",
+                income = false,
+                expense = true,
+                createdAt = MOCK_TIME.plusSeconds(300),
+            )
+            category(
+                workspace = it.workspace,
+                name = "Slurm sales",
+                income = true,
+                expense = true,
+                createdAt = MOCK_TIME.plusSeconds(400),
+            )
+            category(
+                workspace = it.workspace,
+                name = "Neutral archive",
+                income = false,
+                expense = false,
+                createdAt = MOCK_TIME.plusSeconds(500),
+            )
+        }
+
+        @Test
+        fun `should filter categories by free search text in name`() {
+            val testData = preconditions { categoriesForFiltering() }
+
+            client.categoriesRawQuery(testData.workspace.id!!, "freeSearchText: \"delivery\"")
+                .from(testData.fry)
+                .executeAndVerifyResponse(categoriesResponse("Delivery expense", "Delivery income", totalCount = 2))
+        }
+
+        @Test
+        fun `should filter categories by free search text case insensitively`() {
+            val testData = preconditions { categoriesForFiltering() }
+
+            client.categoriesRawQuery(testData.workspace.id!!, "freeSearchText: \"rObOt\"")
+                .from(testData.fry)
+                .executeAndVerifyResponse(categoriesResponse("Robot maintenance", totalCount = 1))
+        }
+
+        @Test
+        fun `should filter categories by income type`() {
+            val testData = preconditions { categoriesForFiltering() }
+
+            client.categoriesRawQuery(testData.workspace.id!!, "typeIn: [INCOME]")
+                .from(testData.fry)
+                .executeAndVerifyResponse(categoriesResponse("Slurm sales", "Delivery income", totalCount = 2))
+        }
+
+        @Test
+        fun `should filter categories by expense type`() {
+            val testData = preconditions { categoriesForFiltering() }
+
+            client.categoriesRawQuery(testData.workspace.id!!, "typeIn: [EXPENSE]")
+                .from(testData.fry)
+                .executeAndVerifyResponse(categoriesResponse(
+                    "Slurm sales",
+                    "Robot maintenance",
+                    "Delivery expense",
+                    totalCount = 3,
+                ))
+        }
+
+        @Test
+        fun `should apply OR logic between category types`() {
+            val testData = preconditions { categoriesForFiltering() }
+
+            client.categoriesRawQuery(testData.workspace.id!!, "typeIn: [INCOME, EXPENSE]")
+                .from(testData.fry)
+                .executeAndVerifyResponse(categoriesResponse(
+                    "Slurm sales",
+                    "Robot maintenance",
+                    "Delivery expense",
+                    "Delivery income",
+                    totalCount = 4,
+                ))
+        }
+
+        @Test
+        fun `should not apply category type filter when empty list is provided`() {
+            val testData = preconditions { categoriesForFiltering() }
+
+            client.categoriesRawQuery(testData.workspace.id!!, "typeIn: []")
+                .from(testData.fry)
+                .executeAndVerifyResponse(categoriesResponse(
+                    "Neutral archive",
+                    "Slurm sales",
+                    "Robot maintenance",
+                    "Delivery expense",
+                    "Delivery income",
+                    totalCount = 5,
+                ))
+        }
+
+        @Test
+        fun `should combine free search and type filters with AND logic`() {
+            val testData = preconditions { categoriesForFiltering() }
+
+            client.categoriesRawQuery(testData.workspace.id!!, "freeSearchText: \"delivery\", typeIn: [EXPENSE]")
+                .from(testData.fry)
+                .executeAndVerifyResponse(categoriesResponse("Delivery expense", totalCount = 1))
+        }
+
+        @Test
+        fun `should return empty connection when combined filters do not match`() {
+            val testData = preconditions { categoriesForFiltering() }
+
+            client.categoriesRawQuery(testData.workspace.id!!, "freeSearchText: \"robot\", typeIn: [INCOME]")
+                .from(testData.fry)
+                .executeAndVerifyResponse(
+                    "workspace" to buildJsonObject {
+                        put("categories", buildJsonObject {
+                            putJsonArray("edges") {}
+                            put("totalCount", 0)
+                        })
+                    }
+                )
+        }
+    }
 }
+
+private fun ApiTestClient.categoriesRawQuery(workspaceId: String, args: String) = graphqlRawQuery(
+    """
+        query {
+          workspace(id: "$workspaceId") {
+            categories(first: 10, $args) {
+              edges {
+                node { name }
+              }
+              totalCount
+            }
+          }
+        }
+    """.trimIndent()
+)
+
+private fun categoriesResponse(vararg categoryNames: String, totalCount: Int): Pair<String, JsonElement> =
+    "workspace" to buildJsonObject {
+        put("categories", buildJsonObject {
+            putJsonArray("edges") {
+                categoryNames.forEach { categoryEdge(name = it) }
+            }
+            put("totalCount", totalCount)
+        })
+    }
 
 private fun kotlinx.serialization.json.JsonArrayBuilder.categoryEdge(name: String) {
     add(buildJsonObject {

--- a/app/src/test/resources/api-schema.graphqls
+++ b/app/src/test/resources/api-schema.graphqls
@@ -1283,7 +1283,11 @@ type Workspace {
     "Cursor after which to return items."
     after: String,
     "The maximum number of items to return."
-    first: Int!
+    first: Int!,
+    "Optional free text search to filter categories by name."
+    freeSearchText: String,
+    "Optional filter to include categories matching any of the specified usage types."
+    typeIn: [CategoryType!]
   ): CategoriesConnection!
   "Returns a category by its ID if it belongs to this workspace, or null if not found."
   category(
@@ -1510,6 +1514,12 @@ enum AuthType {
   AUTHENTICATED_USER
   "Requires a request to be executed by a regular user, i.e. authenticated and not an admin user."
   REGULAR_USER
+}
+
+"Category usage type."
+enum CategoryType {
+  EXPENSE
+  INCOME
 }
 
 "Possible business error codes for the changePassword operation."

--- a/frontend/src/services/api/gql/schema-types.ts
+++ b/frontend/src/services/api/gql/schema-types.ts
@@ -84,6 +84,12 @@ export type CategoryEdge = {
   node: Category;
 };
 
+/** Category usage type. */
+export enum CategoryType {
+  Expense = 'EXPENSE',
+  Income = 'INCOME'
+}
+
 /** Possible business error codes for the changePassword operation. */
 export enum ChangePasswordErrorCodes {
   /** The provided current password does not match the user's actual password. */
@@ -1438,6 +1444,8 @@ export type Workspace = {
 export type WorkspaceCategoriesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   first: Scalars['Int']['input'];
+  freeSearchText?: InputMaybe<Scalars['String']['input']>;
+  typeIn?: InputMaybe<Array<CategoryType>>;
 };
 
 


### PR DESCRIPTION
## Problem statement

The categories pageable API did not support filtering by category name or category usage type.

## Solution summary

Add `freeSearchText` and `typeIn` filters to the categories GraphQL connection, apply OR logic for requested category types and AND logic across filters, and cover the new behavior with extensive API tests.

## Notes

N/A
