### PR TITLE
refactor(frontend): extract shared page layouts

### DIFF
--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/workspaces/WorkspacesOverviewPage.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/workspaces/WorkspacesOverviewPage.kt
@@ -49,7 +49,7 @@ class WorkspacePanel(
 
 class WorkspacesOverviewPage private constructor(page: Page) : SaPageBase(page) {
     private val header = components.pageHeader()
-    val createButton = components.buttonByContainer(page.locator(".sa-page-header .sa-header-options"))
+    val createButton = components.buttonByContainer(page.locator(".sa-page__header-options"))
 
     val pageItems = components.workspacePanelItems()
 

--- a/frontend/src/components/SaOverviewPage.vue
+++ b/frontend/src/components/SaOverviewPage.vue
@@ -19,6 +19,16 @@
         </ElInput>
       </div>
 
+      <ElButton
+        v-if="createActionVisible"
+        round
+        :disabled="createActionDisabled"
+        @click="navigateToCreateAction"
+      >
+        <SaIcon icon="plus-thin" />
+        {{ createActionLabel }}
+      </ElButton>
+
       <slot name="actions" />
     </template>
 
@@ -27,19 +37,35 @@
 </template>
 
 <script lang="ts" setup>
+  import { computed } from 'vue';
   import { Search } from '@element-plus/icons-vue';
   import SaPage from '@/components/SaPage.vue';
+  import SaIcon from '@/components/SaIcon.vue';
   import { $t } from '@/services/i18n';
+  import useNavigation from '@/services/use-navigation';
 
-  defineProps<{
+  const props = withDefaults(defineProps<{
     header: string,
     filterPlaceholder?: string,
     modelValue?: string,
-  }>();
+    createActionAvailable?: boolean,
+    createActionDisabled?: boolean,
+    createActionLabel?: string,
+    createActionViewName?: string,
+  }>(), {
+    createActionAvailable: true,
+    createActionDisabled: false,
+  });
 
   const emit = defineEmits<{
     'update:modelValue': [value: string | undefined],
   }>();
+
+  const { navigateByViewName } = useNavigation();
+  const createActionVisible = computed(() => props.createActionAvailable
+    && props.createActionLabel != null
+    && props.createActionViewName != null);
+  const navigateToCreateAction = () => navigateByViewName(props.createActionViewName!);
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/src/components/SaOverviewPage.vue
+++ b/frontend/src/components/SaOverviewPage.vue
@@ -1,0 +1,64 @@
+<template>
+  <SaPage :header="header">
+    <template #header-options>
+      <div>
+        <span>{{ announcement }}</span>
+      </div>
+
+      <div v-if="filterPlaceholder">
+        <ElInput
+          class="sa-overview-page__filter-input"
+          :model-value="modelValue"
+          :placeholder="filterPlaceholder"
+          clearable
+          @update:model-value="emit('update:modelValue', $event)"
+        >
+          <template #prefix>
+            <Search class="sa-overview-page__filter-input__icon" />
+          </template>
+        </ElInput>
+      </div>
+
+      <slot name="actions" />
+    </template>
+
+    <slot />
+  </SaPage>
+</template>
+
+<script lang="ts" setup>
+  import { Search } from '@element-plus/icons-vue';
+  import SaPage from '@/components/SaPage.vue';
+
+  defineProps<{
+    header: string,
+    announcement: string,
+    filterPlaceholder?: string,
+    modelValue?: string,
+  }>();
+
+  const emit = defineEmits<{
+    'update:modelValue': [value: string | undefined],
+  }>();
+</script>
+
+<style lang="scss" scoped>
+  @use "@/styles/vars.scss" as *;
+
+  .sa-overview-page {
+    &__filter-input {
+      :deep(.el-input__wrapper) {
+        background-color: transparent;
+        border: none;
+        box-shadow: none;
+        color: $secondary-text-color;
+        max-width: 200px;
+      }
+
+      &__icon {
+        width: 16px;
+        height: 16px;
+      }
+    }
+  }
+</style>

--- a/frontend/src/components/SaOverviewPage.vue
+++ b/frontend/src/components/SaOverviewPage.vue
@@ -2,7 +2,7 @@
   <SaPage :header="header">
     <template #header-options>
       <div>
-        <span>{{ announcement }}</span>
+        <span>{{ $t.overviewPage.filters.announcement() }}</span>
       </div>
 
       <div v-if="filterPlaceholder">
@@ -29,10 +29,10 @@
 <script lang="ts" setup>
   import { Search } from '@element-plus/icons-vue';
   import SaPage from '@/components/SaPage.vue';
+  import { $t } from '@/services/i18n';
 
   defineProps<{
     header: string,
-    announcement: string,
     filterPlaceholder?: string,
     modelValue?: string,
   }>();

--- a/frontend/src/components/SaPage.vue
+++ b/frontend/src/components/SaPage.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="sa-page">
+    <div
+      v-if="header || $slots.header || $slots['header-options']"
+      class="sa-page__header"
+    >
+      <slot name="header">
+        <h1 v-if="header">{{ header }}</h1>
+      </slot>
+
+      <div
+        v-if="$slots['header-options']"
+        class="sa-page__header-options"
+      >
+        <slot name="header-options" />
+      </div>
+    </div>
+
+    <slot />
+  </div>
+</template>
+
+<script lang="ts" setup>
+  defineProps<{
+    header?: string,
+  }>();
+</script>
+
+<style lang="scss" scoped>
+  @use "@/styles/vars.scss" as *;
+
+  .sa-page {
+    &__header {
+      h1 {
+        margin-top: 0;
+        margin-bottom: 10px;
+        font-size: 160%;
+      }
+
+      &:after {
+        content: "";
+        display: block;
+        width: 100%;
+        height: 1px;
+        margin-top: 10px;
+        margin-bottom: 30px;
+        background: $secondary-grey;
+      }
+    }
+
+    &__header-options {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+  }
+</style>

--- a/frontend/src/pages/admin/users/EditUser.vue
+++ b/frontend/src/pages/admin/users/EditUser.vue
@@ -1,8 +1,5 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ pageHeader }}</h1>
-    </div>
+  <SaPage :header="pageHeader">
     <SaForm v-model="formValues" :on-submit="saveUser" :on-load="loadUser" :on-cancel="navigateToUsersOverview">
       <SaFormInput prop="userName" :label="$t.editUser.form.userName.label()" />
       <SaFormSelect
@@ -29,12 +26,13 @@
         </template>
       </ElFormItem>
     </SaForm>
-  </div>
+  </SaPage>
 </template>
 
 <script lang="ts" setup>
   import { computed, ref } from 'vue';
   import { $t } from '@/services/i18n';
+  import SaPage from '@/components/SaPage.vue';
   import SaForm from '@/components/form/SaForm.vue';
   import useNavigation from '@/services/use-navigation';
   import { handleGqlApiBusinessError } from '@/services/api';

--- a/frontend/src/pages/admin/users/UsersOverview.vue
+++ b/frontend/src/pages/admin/users/UsersOverview.vue
@@ -1,35 +1,18 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ $t.usersOverview.header() }}</h1>
-
-      <div class="sa-header-options">
-        <div>
-          <span>{{ $t.usersOverview.filters.announcement() }}</span>
-        </div>
-
-        <div>
-          <ElInput
-            class="sa-header-options__filter-input"
-            v-model="freeSearchText"
-            :placeholder="$t.usersOverview.filters.input.placeholder()"
-            clearable
-          >
-            <template #prefix>
-              <Search class="sa-header-options__filter-input__icon" />
-            </template>
-          </ElInput>
-        </div>
-
-        <ElButton
-          round
-          @click="navigateToCreateUserView"
-        >
-          <SaIcon icon="plus-thin" />
-          {{ $t.usersOverview.create() }}
-        </ElButton>
-      </div>
-    </div>
+  <SaOverviewPage
+    v-model="freeSearchText"
+    :header="$t.usersOverview.header()"
+    :filter-placeholder="$t.usersOverview.filters.input.placeholder()"
+  >
+    <template #actions>
+      <ElButton
+        round
+        @click="navigateToCreateUserView"
+      >
+        <SaIcon icon="plus-thin" />
+        {{ $t.usersOverview.create() }}
+      </ElButton>
+    </template>
 
     <SaPageableItems
       :page-query="usersPageQuery"
@@ -39,12 +22,12 @@
     >
       <UsersOverviewPanel :user="item" />
     </SaPageableItems>
-  </div>
+  </SaOverviewPage>
 </template>
 
 <script lang="ts" setup>
   import { ref } from 'vue';
-  import { Search } from '@element-plus/icons-vue';
+  import SaOverviewPage from '@/components/SaOverviewPage.vue';
   import SaIcon from '@/components/SaIcon.vue';
   import useNavigation from '@/services/use-navigation';
   import { $t } from '@/services/i18n';

--- a/frontend/src/pages/admin/users/UsersOverview.vue
+++ b/frontend/src/pages/admin/users/UsersOverview.vue
@@ -3,17 +3,9 @@
     v-model="freeSearchText"
     :header="$t.usersOverview.header()"
     :filter-placeholder="$t.usersOverview.filters.input.placeholder()"
+    :create-action-label="$t.usersOverview.create()"
+    create-action-view-name="create-new-user"
   >
-    <template #actions>
-      <ElButton
-        round
-        @click="navigateToCreateUserView"
-      >
-        <SaIcon icon="plus-thin" />
-        {{ $t.usersOverview.create() }}
-      </ElButton>
-    </template>
-
     <SaPageableItems
       :page-query="usersPageQuery"
       path="users"
@@ -28,8 +20,6 @@
 <script lang="ts" setup>
   import { ref } from 'vue';
   import SaOverviewPage from '@/components/SaOverviewPage.vue';
-  import SaIcon from '@/components/SaIcon.vue';
-  import useNavigation from '@/services/use-navigation';
   import { $t } from '@/services/i18n';
   import UsersOverviewPanel from '@/pages/admin/users/UsersOverviewPanel.vue';
   import { graphql } from '@/services/api/gql';
@@ -57,6 +47,4 @@
 
   const freeSearchText = ref<string | undefined>();
 
-  const { navigateByViewName } = useNavigation();
-  const navigateToCreateUserView = () => navigateByViewName('create-new-user');
 </script>

--- a/frontend/src/pages/dashboard/Dashboard.vue
+++ b/frontend/src/pages/dashboard/Dashboard.vue
@@ -1,23 +1,19 @@
 <template>
-  <div class="sa-dashboard">
-    <div class="sa-page-header">
-      <h1>{{ $t.dashboard.header() }}</h1>
+  <SaPage class="sa-dashboard" :header="$t.dashboard.header()">
+    <template #header-options>
+      <span>&nbsp;</span>
 
-      <div class="sa-header-options">
-        <span>&nbsp;</span>
-
-        <!--suppress HtmlDeprecatedAttribute -->
-        <ElDatePicker
-          v-model="selectedDateRange"
-          type="daterange"
-          align="right"
-          unlink-panels
-          :range-separator="$t.dashboard.dateRange.separator()"
-          :start-placeholder="$t.dashboard.dateRange.startPlaceholder()"
-          :end-placeholder="$t.dashboard.dateRange.endPlaceholder()"
-        />
-      </div>
-    </div>
+      <!--suppress HtmlDeprecatedAttribute -->
+      <ElDatePicker
+        v-model="selectedDateRange"
+        type="daterange"
+        align="right"
+        unlink-panels
+        :range-separator="$t.dashboard.dateRange.separator()"
+        :start-placeholder="$t.dashboard.dateRange.startPlaceholder()"
+        :end-placeholder="$t.dashboard.dateRange.endPlaceholder()"
+      />
+    </template>
 
     <div class="sa-dashboard__row">
       <DashboardCardExpenses
@@ -39,11 +35,12 @@
         :invoices="invoicesData"
       />
     </div>
-  </div>
+  </SaPage>
 </template>
 
 <script lang="ts" setup>
   import { ref, computed, watch } from 'vue';
+  import SaPage from '@/components/SaPage.vue';
   import { useStorage } from '@/services/storage';
   import DashboardCardExpenses from '@/pages/dashboard/DashboardCardExpenses.vue';
   import DashboardCardIncomes from '@/pages/dashboard/DashboardCardIncomes.vue';

--- a/frontend/src/pages/dashboard/Dashboard.vue
+++ b/frontend/src/pages/dashboard/Dashboard.vue
@@ -1,5 +1,5 @@
 <template>
-  <SaPage class="sa-dashboard" :header="$t.dashboard.header()">
+  <SaPage :header="$t.dashboard.header()">
     <template #header-options>
       <span>&nbsp;</span>
 

--- a/frontend/src/pages/documents/DocumentsMigration.vue
+++ b/frontend/src/pages/documents/DocumentsMigration.vue
@@ -1,8 +1,5 @@
 <template>
-  <div class="sa-documents-migration-page">
-    <div class="sa-page-header">
-      <h1>{{ $t.documentsMigration.pageHeader() }}</h1>
-    </div>
+  <SaPage class="sa-documents-migration-page" :header="$t.documentsMigration.pageHeader()">
 
     <div
       v-if="loading"
@@ -61,11 +58,12 @@
         </div>
       </div>
     </div>
-  </div>
+  </SaPage>
 </template>
 
 <script lang="ts" setup>
   import { computed, ref } from 'vue';
+  import SaPage from '@/components/SaPage.vue';
   import { graphql } from '@/services/api/gql';
   import { useMultiQuery, useMutation } from '@/services/api/use-gql-api.ts';
   import { $t } from '@/services/i18n';

--- a/frontend/src/pages/documents/DocumentsMigration.vue
+++ b/frontend/src/pages/documents/DocumentsMigration.vue
@@ -1,5 +1,5 @@
 <template>
-  <SaPage class="sa-documents-migration-page" :header="$t.documentsMigration.pageHeader()">
+  <SaPage :header="$t.documentsMigration.pageHeader()">
 
     <div
       v-if="loading"

--- a/frontend/src/pages/documents/DocumentsOverview.vue
+++ b/frontend/src/pages/documents/DocumentsOverview.vue
@@ -1,17 +1,11 @@
 <template>
-  <SaOverviewPage :header="$t.documentsOverview.header()">
-    <template #actions>
-      <ElButton
-        v-if="isCurrentUserRegular()"
-        round
-        :disabled="!currentWorkspace.editable"
-        @click="navigateToCreateStandaloneDocumentView"
-      >
-        <SaIcon icon="plus-thin" />
-        {{ $t.documentsOverview.create() }}
-      </ElButton>
-    </template>
-
+  <SaOverviewPage
+    :header="$t.documentsOverview.header()"
+    :create-action-label="$t.documentsOverview.create()"
+    create-action-view-name="create-standalone-document"
+    :create-action-available="isCurrentUserRegular()"
+    :create-action-disabled="!currentWorkspace.editable"
+  >
     <SaPageableItems
       ref="pageItems"
       :page-query="documentsPageQuery"
@@ -30,22 +24,18 @@
 <script lang="ts" setup>
   import { ref } from 'vue';
   import SaOverviewPage from '@/components/SaOverviewPage.vue';
-  import SaIcon from '@/components/SaIcon.vue';
   import SaPageableItems from '@/components/pageable-items/SaPageableItems.vue';
   import DocumentsOverviewPanel from '@/pages/documents/DocumentsOverviewPanel.vue';
   import { useCurrentWorkspace } from '@/services/workspaces';
   import { graphql } from '@/services/api/gql';
   import { $t } from '@/services/i18n';
-  import useNavigation from '@/services/use-navigation';
   import { useAuth } from '@/services/api';
 
   const { currentWorkspaceId, currentWorkspace } = useCurrentWorkspace();
   const { isCurrentUserRegular } = useAuth();
   const pageItems = ref<{ reload: () => void }>();
-  const { navigateByViewName } = useNavigation();
 
   const reloadDocuments = () => pageItems.value?.reload();
-  const navigateToCreateStandaloneDocumentView = () => navigateByViewName('create-standalone-document');
 
   const documentsPageQuery = graphql(`
     query documentsPage($workspaceId: String!, $first: Int!, $after: String) {

--- a/frontend/src/pages/documents/DocumentsOverview.vue
+++ b/frontend/src/pages/documents/DocumentsOverview.vue
@@ -1,24 +1,16 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ $t.documentsOverview.header() }}</h1>
-
-      <div class="sa-header-options">
-        <div>
-          <span>{{ $t.documentsOverview.filters.announcement() }}</span>
-        </div>
-
-        <ElButton
-          v-if="isCurrentUserRegular()"
-          round
-          :disabled="!currentWorkspace.editable"
-          @click="navigateToCreateStandaloneDocumentView"
-        >
-          <SaIcon icon="plus-thin" />
-          {{ $t.documentsOverview.create() }}
-        </ElButton>
-      </div>
-    </div>
+  <SaOverviewPage :header="$t.documentsOverview.header()">
+    <template #actions>
+      <ElButton
+        v-if="isCurrentUserRegular()"
+        round
+        :disabled="!currentWorkspace.editable"
+        @click="navigateToCreateStandaloneDocumentView"
+      >
+        <SaIcon icon="plus-thin" />
+        {{ $t.documentsOverview.create() }}
+      </ElButton>
+    </template>
 
     <SaPageableItems
       ref="pageItems"
@@ -32,11 +24,12 @@
         @deleted="reloadDocuments"
       />
     </SaPageableItems>
-  </div>
+  </SaOverviewPage>
 </template>
 
 <script lang="ts" setup>
   import { ref } from 'vue';
+  import SaOverviewPage from '@/components/SaOverviewPage.vue';
   import SaIcon from '@/components/SaIcon.vue';
   import SaPageableItems from '@/components/pageable-items/SaPageableItems.vue';
   import DocumentsOverviewPanel from '@/pages/documents/DocumentsOverviewPanel.vue';

--- a/frontend/src/pages/documents/EditStandaloneDocument.vue
+++ b/frontend/src/pages/documents/EditStandaloneDocument.vue
@@ -1,8 +1,5 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ pageHeader }}</h1>
-    </div>
+  <SaPage :header="pageHeader">
 
     <SaForm
       v-model="formValues"
@@ -35,11 +32,12 @@
         </div>
       </div>
     </SaForm>
-  </div>
+  </SaPage>
 </template>
 
 <script lang="ts" setup>
   import { computed, ref } from 'vue';
+  import SaPage from '@/components/SaPage.vue';
   import SaForm from '@/components/form/SaForm.vue';
   import SaFormInput from '@/components/form/SaFormInput.vue';
   import SaFormDocumentsUpload from '@/components/form/SaFormDocumentsUpload.vue';

--- a/frontend/src/pages/expenses/EditExpense.vue
+++ b/frontend/src/pages/expenses/EditExpense.vue
@@ -1,8 +1,5 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ pageHeader }}</h1>
-    </div>
+  <SaPage :header="pageHeader">
 
     <SaForm
       v-model="formValues"
@@ -102,11 +99,12 @@
         </div>
       </div>
     </SaForm>
-  </div>
+  </SaPage>
 </template>
 
 <script lang="ts" setup>
   import { computed, ref } from 'vue';
+  import SaPage from '@/components/SaPage.vue';
   import SaForm from '@/components/form/SaForm.vue';
   import SaFormInput from '@/components/form/SaFormInput.vue';
   import SaFormMoneyInput from '@/components/form/SaFormMoneyInput.vue';

--- a/frontend/src/pages/expenses/ExpensesOverview.vue
+++ b/frontend/src/pages/expenses/ExpensesOverview.vue
@@ -1,36 +1,20 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ $t.expensesOverview.header() }}</h1>
-
-      <div class="sa-header-options">
-        <div>
-          <span>{{ $t.expensesOverview.filters.announcement() }}</span>
-        </div>
-
-        <div>
-          <ElInput
-            class="sa-header-options__filter-input"
-            v-model="freeSearchText"
-            :placeholder="$t.expensesOverview.filters.input.placeholder()"
-            clearable
-          >
-            <template #prefix>
-              <Search class="sa-header-options__filter-input__icon" />
-            </template>
-          </ElInput>
-        </div>
-
-        <ElButton
-          round
-          :disabled="!currentWorkspace.editable"
-          @click="navigateToCreateExpenseView"
-        >
-          <SaIcon icon="plus-thin" />
-          {{ $t.expensesOverview.create() }}
-        </ElButton>
-      </div>
-    </div>
+  <SaOverviewPage
+    v-model="freeSearchText"
+    :header="$t.expensesOverview.header()"
+    :announcement="$t.expensesOverview.filters.announcement()"
+    :filter-placeholder="$t.expensesOverview.filters.input.placeholder()"
+  >
+    <template #actions>
+      <ElButton
+        round
+        :disabled="!currentWorkspace.editable"
+        @click="navigateToCreateExpenseView"
+      >
+        <SaIcon icon="plus-thin" />
+        {{ $t.expensesOverview.create() }}
+      </ElButton>
+    </template>
 
     <SaPageableItems
       #default="{ item: expense }"
@@ -40,12 +24,12 @@
     >
       <ExpensesOverviewPanel :expense="expense" />
     </SaPageableItems>
-  </div>
+  </SaOverviewPage>
 </template>
 
 <script lang="ts" setup>
   import { ref } from 'vue';
-  import { Search } from '@element-plus/icons-vue';
+  import SaOverviewPage from '@/components/SaOverviewPage.vue';
   import SaIcon from '@/components/SaIcon.vue';
   import ExpensesOverviewPanel from '@/pages/expenses/ExpensesOverviewPanel.vue';
   import { useCurrentWorkspace } from '@/services/workspaces';

--- a/frontend/src/pages/expenses/ExpensesOverview.vue
+++ b/frontend/src/pages/expenses/ExpensesOverview.vue
@@ -3,18 +3,10 @@
     v-model="freeSearchText"
     :header="$t.expensesOverview.header()"
     :filter-placeholder="$t.expensesOverview.filters.input.placeholder()"
+    :create-action-label="$t.expensesOverview.create()"
+    create-action-view-name="create-new-expense"
+    :create-action-disabled="!currentWorkspace.editable"
   >
-    <template #actions>
-      <ElButton
-        round
-        :disabled="!currentWorkspace.editable"
-        @click="navigateToCreateExpenseView"
-      >
-        <SaIcon icon="plus-thin" />
-        {{ $t.expensesOverview.create() }}
-      </ElButton>
-    </template>
-
     <SaPageableItems
       #default="{ item: expense }"
       :page-query="expensesPageQuery"
@@ -29,11 +21,9 @@
 <script lang="ts" setup>
   import { ref } from 'vue';
   import SaOverviewPage from '@/components/SaOverviewPage.vue';
-  import SaIcon from '@/components/SaIcon.vue';
   import ExpensesOverviewPanel from '@/pages/expenses/ExpensesOverviewPanel.vue';
   import { useCurrentWorkspace } from '@/services/workspaces';
   import SaPageableItems from '@/components/pageable-items/SaPageableItems.vue';
-  import useNavigation from '@/services/use-navigation';
   import { $t } from '@/services/i18n/i18n-services';
   import { graphql } from '@/services/api/gql';
 
@@ -87,7 +77,4 @@
   const { currentWorkspaceId, currentWorkspace } = useCurrentWorkspace();
 
   const freeSearchText = ref<string | undefined>();
-
-  const { navigateByViewName } = useNavigation();
-  const navigateToCreateExpenseView = () => navigateByViewName('create-new-expense');
 </script>

--- a/frontend/src/pages/expenses/ExpensesOverview.vue
+++ b/frontend/src/pages/expenses/ExpensesOverview.vue
@@ -2,7 +2,6 @@
   <SaOverviewPage
     v-model="freeSearchText"
     :header="$t.expensesOverview.header()"
-    :announcement="$t.expensesOverview.filters.announcement()"
     :filter-placeholder="$t.expensesOverview.filters.input.placeholder()"
   >
     <template #actions>

--- a/frontend/src/pages/income-tax-payments/EditIncomeTaxPayment.vue
+++ b/frontend/src/pages/income-tax-payments/EditIncomeTaxPayment.vue
@@ -1,8 +1,5 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ pageHeader }}</h1>
-    </div>
+  <SaPage :header="pageHeader">
 
     <SaForm v-model="formValues"
             :on-submit="saveTaxPayment"
@@ -56,12 +53,13 @@
         </div>
       </div>
     </SaForm>
-  </div>
+  </SaPage>
 </template>
 
 <script lang="ts" setup>
   import { computed, ref } from 'vue';
   import { $t } from '@/services/i18n';
+  import SaPage from '@/components/SaPage.vue';
   import SaForm from '@/components/form/SaForm.vue';
   import SaFormInput from '@/components/form/SaFormInput.vue';
   import SaFormMoneyInput from '@/components/form/SaFormMoneyInput.vue';

--- a/frontend/src/pages/income-tax-payments/IncomeTaxPaymentsOverview.vue
+++ b/frontend/src/pages/income-tax-payments/IncomeTaxPaymentsOverview.vue
@@ -1,23 +1,15 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ $t.incomeTaxPaymentsOverview.header() }}</h1>
-
-      <div class="sa-header-options">
-        <div>
-          <span>{{ $t.incomeTaxPaymentsOverview.filters.announcement() }}</span>
-        </div>
-
-        <ElButton
-          round
-          :disabled="!currentWorkspace.editable"
-          @click="navigateToCreateTaxPaymentView"
-        >
-          <SaIcon icon="plus-thin" />
-          {{ $t.incomeTaxPaymentsOverview.create() }}
-        </ElButton>
-      </div>
-    </div>
+  <SaOverviewPage :header="$t.incomeTaxPaymentsOverview.header()">
+    <template #actions>
+      <ElButton
+        round
+        :disabled="!currentWorkspace.editable"
+        @click="navigateToCreateTaxPaymentView"
+      >
+        <SaIcon icon="plus-thin" />
+        {{ $t.incomeTaxPaymentsOverview.create() }}
+      </ElButton>
+    </template>
 
     <SaPageableItems
       :page-query="incomeTaxPaymentsPageQuery"
@@ -27,10 +19,11 @@
     >
       <IncomeTaxPaymentsOverviewPanel :tax-payment="taxPayment" />
     </SaPageableItems>
-  </div>
+  </SaOverviewPage>
 </template>
 
 <script lang="ts" setup>
+  import SaOverviewPage from '@/components/SaOverviewPage.vue';
   import SaPageableItems from '@/components/pageable-items/SaPageableItems.vue';
   import SaIcon from '@/components/SaIcon.vue';
   import IncomeTaxPaymentsOverviewPanel from '@/pages/income-tax-payments/IncomeTaxPaymentsOverviewPanel.vue';

--- a/frontend/src/pages/income-tax-payments/IncomeTaxPaymentsOverview.vue
+++ b/frontend/src/pages/income-tax-payments/IncomeTaxPaymentsOverview.vue
@@ -1,16 +1,10 @@
 <template>
-  <SaOverviewPage :header="$t.incomeTaxPaymentsOverview.header()">
-    <template #actions>
-      <ElButton
-        round
-        :disabled="!currentWorkspace.editable"
-        @click="navigateToCreateTaxPaymentView"
-      >
-        <SaIcon icon="plus-thin" />
-        {{ $t.incomeTaxPaymentsOverview.create() }}
-      </ElButton>
-    </template>
-
+  <SaOverviewPage
+    :header="$t.incomeTaxPaymentsOverview.header()"
+    :create-action-label="$t.incomeTaxPaymentsOverview.create()"
+    create-action-view-name="create-new-income-tax-payment"
+    :create-action-disabled="!currentWorkspace.editable"
+  >
     <SaPageableItems
       :page-query="incomeTaxPaymentsPageQuery"
       path="workspace.incomeTaxPayments"
@@ -25,9 +19,7 @@
 <script lang="ts" setup>
   import SaOverviewPage from '@/components/SaOverviewPage.vue';
   import SaPageableItems from '@/components/pageable-items/SaPageableItems.vue';
-  import SaIcon from '@/components/SaIcon.vue';
   import IncomeTaxPaymentsOverviewPanel from '@/pages/income-tax-payments/IncomeTaxPaymentsOverviewPanel.vue';
-  import useNavigation from '@/services/use-navigation';
   import { useCurrentWorkspace } from '@/services/workspaces';
   import { $t } from '@/services/i18n';
   import { graphql } from '@/services/api/gql';
@@ -59,8 +51,6 @@
     }
   `);
 
-  const { navigateByViewName } = useNavigation();
-  const navigateToCreateTaxPaymentView = () => navigateByViewName('create-new-income-tax-payment');
   const {
     currentWorkspace,
     currentWorkspaceId,

--- a/frontend/src/pages/incomes/EditIncome.vue
+++ b/frontend/src/pages/incomes/EditIncome.vue
@@ -1,8 +1,5 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ pageHeader }}</h1>
-    </div>
+  <SaPage :header="pageHeader">
 
     <SaForm
       v-model="formValues"
@@ -95,11 +92,12 @@
         </div>
       </div>
     </SaForm>
-  </div>
+  </SaPage>
 </template>
 
 <script lang="ts" setup>
   import { computed, ref } from 'vue';
+  import SaPage from '@/components/SaPage.vue';
   import SaForm from '@/components/form/SaForm.vue';
   import SaFormInput from '@/components/form/SaFormInput.vue';
   import SaFormMoneyInput from '@/components/form/SaFormMoneyInput.vue';

--- a/frontend/src/pages/incomes/IncomesOverview.vue
+++ b/frontend/src/pages/incomes/IncomesOverview.vue
@@ -1,36 +1,19 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ $t.incomesOverview.header() }}</h1>
-
-      <div class="sa-header-options">
-        <div>
-          <span>{{ $t.incomesOverview.filters.announcement() }}</span>
-        </div>
-
-        <div>
-          <ElInput
-            class="sa-header-options__filter-input"
-            v-model="freeSearchText"
-            :placeholder="$t.incomesOverview.filters.input.placeholder()"
-            clearable
-          >
-            <template #prefix>
-              <Search class="sa-header-options__filter-input__icon" />
-            </template>
-          </ElInput>
-        </div>
-
-        <ElButton
-          round
-          :disabled="!currentWorkspace.editable"
-          @click="navigateToCreateIncomeView"
-        >
-          <SaIcon icon="plus-thin" />
-          {{ $t.incomesOverview.create() }}
-        </ElButton>
-      </div>
-    </div>
+  <SaOverviewPage
+    v-model="freeSearchText"
+    :header="$t.incomesOverview.header()"
+    :filter-placeholder="$t.incomesOverview.filters.input.placeholder()"
+  >
+    <template #actions>
+      <ElButton
+        round
+        :disabled="!currentWorkspace.editable"
+        @click="navigateToCreateIncomeView"
+      >
+        <SaIcon icon="plus-thin" />
+        {{ $t.incomesOverview.create() }}
+      </ElButton>
+    </template>
 
     <SaPageableItems
       #default="{ item: income }"
@@ -40,12 +23,12 @@
     >
       <IncomesOverviewPanel :income="income" />
     </SaPageableItems>
-  </div>
+  </SaOverviewPage>
 </template>
 
 <script lang="ts" setup>
   import { ref } from 'vue';
-  import { Search } from '@element-plus/icons-vue';
+  import SaOverviewPage from '@/components/SaOverviewPage.vue';
   import SaPageableItems from '@/components/pageable-items/SaPageableItems.vue';
   import SaIcon from '@/components/SaIcon.vue';
   import IncomesOverviewPanel from '@/pages/incomes/IncomesOverviewPanel.vue';

--- a/frontend/src/pages/incomes/IncomesOverview.vue
+++ b/frontend/src/pages/incomes/IncomesOverview.vue
@@ -3,18 +3,10 @@
     v-model="freeSearchText"
     :header="$t.incomesOverview.header()"
     :filter-placeholder="$t.incomesOverview.filters.input.placeholder()"
+    :create-action-label="$t.incomesOverview.create()"
+    create-action-view-name="create-new-income"
+    :create-action-disabled="!currentWorkspace.editable"
   >
-    <template #actions>
-      <ElButton
-        round
-        :disabled="!currentWorkspace.editable"
-        @click="navigateToCreateIncomeView"
-      >
-        <SaIcon icon="plus-thin" />
-        {{ $t.incomesOverview.create() }}
-      </ElButton>
-    </template>
-
     <SaPageableItems
       #default="{ item: income }"
       :page-query="incomesPageQuery"
@@ -30,10 +22,8 @@
   import { ref } from 'vue';
   import SaOverviewPage from '@/components/SaOverviewPage.vue';
   import SaPageableItems from '@/components/pageable-items/SaPageableItems.vue';
-  import SaIcon from '@/components/SaIcon.vue';
   import IncomesOverviewPanel from '@/pages/incomes/IncomesOverviewPanel.vue';
   import { useCurrentWorkspace } from '@/services/workspaces';
-  import useNavigation from '@/services/use-navigation';
   import { $t } from '@/services/i18n';
   import { graphql } from '@/services/api/gql';
 
@@ -90,7 +80,4 @@
   const { currentWorkspaceId, currentWorkspace } = useCurrentWorkspace();
 
   const freeSearchText = ref<string | undefined>();
-
-  const { navigateByViewName } = useNavigation();
-  const navigateToCreateIncomeView = () => navigateByViewName('create-new-income');
 </script>

--- a/frontend/src/pages/invoices/EditInvoice.vue
+++ b/frontend/src/pages/invoices/EditInvoice.vue
@@ -1,28 +1,21 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ pageHeader }}</h1>
-
-      <div
-        v-if="uiState.isEditing"
-        class="sa-header-options"
+  <SaPage :header="pageHeader">
+    <template v-if="uiState.isEditing" #header-options>
+      <span />
+      <ElButton
+        v-if="uiState.status !== 'CANCELLED'"
+        type="danger"
+        @click="cancelInvoice"
       >
-        <span />
-        <ElButton
-          v-if="uiState.status !== 'CANCELLED'"
-          type="danger"
-          @click="cancelInvoice"
-        >
-          {{ $t.editInvoice.cancelInvoice.button() }}
-        </ElButton>
-        <SaStatusLabel
-          v-if="uiState.status === 'CANCELLED'"
-          status="failure"
-        >
-          {{ $t.editInvoice.cancelInvoice.status() }}
-        </SaStatusLabel>
-      </div>
-    </div>
+        {{ $t.editInvoice.cancelInvoice.button() }}
+      </ElButton>
+      <SaStatusLabel
+        v-if="uiState.status === 'CANCELLED'"
+        status="failure"
+      >
+        {{ $t.editInvoice.cancelInvoice.status() }}
+      </SaStatusLabel>
+    </template>
 
     <SaForm
       v-model="formValues"
@@ -118,12 +111,13 @@
           </div>
         </div>
     </SaForm>
-  </div>
+  </SaPage>
 </template>
 
 <script lang="ts" setup>
   import { computed, ref } from 'vue';
   import { $t } from '@/services/i18n';
+  import SaPage from '@/components/SaPage.vue';
   import SaForm from '@/components/form/SaForm.vue';
   import SaFormInput from '@/components/form/SaFormInput.vue';
   import SaFormCustomerInput from '@/components/form/SaFormCustomerInput.vue';

--- a/frontend/src/pages/invoices/InvoicesOverview.vue
+++ b/frontend/src/pages/invoices/InvoicesOverview.vue
@@ -3,18 +3,10 @@
     v-model="invoicesFilter"
     :header="$t.invoicesOverview.header()"
     :filter-placeholder="$t.invoicesOverview.filters.input.placeholder()"
+    :create-action-label="$t.invoicesOverview.create()"
+    create-action-view-name="create-new-invoice"
+    :create-action-disabled="!currentWorkspace.editable"
   >
-    <template #actions>
-      <ElButton
-        round
-        :disabled="!currentWorkspace.editable"
-        @click="navigateToCreateInvoiceView"
-      >
-        <SaIcon icon="plus-thin" />
-        {{ $t.invoicesOverview.create() }}
-      </ElButton>
-    </template>
-
     <SaPageableItems
       ref="pageableItemsRef"
       #default="{ item: invoice }"
@@ -31,9 +23,7 @@
   import { ref } from 'vue';
   import SaOverviewPage from '@/components/SaOverviewPage.vue';
   import SaPageableItems from '@/components/pageable-items/SaPageableItems.vue';
-  import SaIcon from '@/components/SaIcon.vue';
   import InvoicesOverviewPanel from '@/pages/invoices/InvoicesOverviewPanel.vue';
-  import useNavigation from '@/services/use-navigation';
   import { useCurrentWorkspace } from '@/services/workspaces';
   import { $t } from '@/services/i18n';
   import { graphql } from '@/services/api/gql';
@@ -85,12 +75,6 @@
     currentWorkspaceId,
     currentWorkspace,
   } = useCurrentWorkspace();
-
-  const { navigateByViewName } = useNavigation();
-
-  const navigateToCreateInvoiceView = () => {
-    navigateByViewName('create-new-invoice');
-  };
 
   const onInvoiceUpdate = () => {
     pageableItemsRef.value?.reload();

--- a/frontend/src/pages/invoices/InvoicesOverview.vue
+++ b/frontend/src/pages/invoices/InvoicesOverview.vue
@@ -1,36 +1,19 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ $t.invoicesOverview.header() }}</h1>
-
-      <div class="sa-header-options">
-        <div>
-          <span>{{ $t.invoicesOverview.filters.announcement() }}</span>
-        </div>
-
-        <div>
-          <ElInput
-            class="sa-header-options__filter-input"
-            v-model="invoicesFilter"
-            :placeholder="$t.invoicesOverview.filters.input.placeholder()"
-            clearable
-          >
-            <template #prefix>
-              <Search class="sa-header-options__filter-input__icon" />
-            </template>
-          </ElInput>
-        </div>
-
-        <ElButton
-          round
-          :disabled="!currentWorkspace.editable"
-          @click="navigateToCreateInvoiceView"
-        >
-          <SaIcon icon="plus-thin" />
-          {{ $t.invoicesOverview.create() }}
-        </ElButton>
-      </div>
-    </div>
+  <SaOverviewPage
+    v-model="invoicesFilter"
+    :header="$t.invoicesOverview.header()"
+    :filter-placeholder="$t.invoicesOverview.filters.input.placeholder()"
+  >
+    <template #actions>
+      <ElButton
+        round
+        :disabled="!currentWorkspace.editable"
+        @click="navigateToCreateInvoiceView"
+      >
+        <SaIcon icon="plus-thin" />
+        {{ $t.invoicesOverview.create() }}
+      </ElButton>
+    </template>
 
     <SaPageableItems
       ref="pageableItemsRef"
@@ -41,12 +24,12 @@
     >
       <InvoicesOverviewPanel :invoice="invoice" @invoice-update="onInvoiceUpdate" />
     </SaPageableItems>
-  </div>
+  </SaOverviewPage>
 </template>
 
 <script lang="ts" setup>
   import { ref } from 'vue';
-  import { Search } from '@element-plus/icons-vue';
+  import SaOverviewPage from '@/components/SaOverviewPage.vue';
   import SaPageableItems from '@/components/pageable-items/SaPageableItems.vue';
   import SaIcon from '@/components/SaIcon.vue';
   import InvoicesOverviewPanel from '@/pages/invoices/InvoicesOverviewPanel.vue';

--- a/frontend/src/pages/my-profile/MyProfile.vue
+++ b/frontend/src/pages/my-profile/MyProfile.vue
@@ -1,8 +1,5 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ $t.myProfile.pageHeader() }}</h1>
-    </div>
+  <SaPage :header="$t.myProfile.pageHeader()">
 
     <MyProfileDocumentsStorage
       v-if="!isAdmin()"
@@ -18,10 +15,11 @@
     />
 
     <MyProfileChangePassword />
-  </div>
+  </SaPage>
 </template>
 
 <script lang="ts" setup>
+  import SaPage from '@/components/SaPage.vue';
   import MyProfileDocumentsStorage from '@/pages/my-profile/MyProfileDocumentsStorage.vue';
   import MyProfileLanguagePreferences from '@/pages/my-profile/MyProfileLanguagePreferences.vue';
   import { useAuth } from '@/services/api';

--- a/frontend/src/pages/reporting/Reporting.vue
+++ b/frontend/src/pages/reporting/Reporting.vue
@@ -1,8 +1,5 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ $t.reporting.header() }}</h1>
-    </div>
+  <SaPage :header="$t.reporting.header()">
 
     <!-- todo #64: navigation between steps-->
 
@@ -79,11 +76,12 @@
         />
       </div>
     </div>
-  </div>
+  </SaPage>
 </template>
 
 <script lang="ts" setup>
   import { computed, ref } from 'vue';
+  import SaPage from '@/components/SaPage.vue';
   import GeneralTaxReport from '@/pages/reporting/GeneralTaxReport.vue';
   import SaIcon from '@/components/SaIcon.vue';
   import { apiDateString } from '@/services/api';

--- a/frontend/src/pages/settings/categories/Categories.vue
+++ b/frontend/src/pages/settings/categories/Categories.vue
@@ -1,15 +1,9 @@
 <template>
-  <SaOverviewPage :header="$t.categoriesOverview.header()">
-    <template #actions>
-      <ElButton
-        round
-        @click="navigateToNewCategoryView"
-      >
-        <SaIcon icon="plus-thin" />
-        {{ $t.categoriesOverview.create() }}
-      </ElButton>
-    </template>
-
+  <SaOverviewPage
+    :header="$t.categoriesOverview.header()"
+    :create-action-label="$t.categoriesOverview.create()"
+    create-action-view-name="create-new-category"
+  >
     <SaPageableItems
       :page-query="categoriesPageQuery"
       path="workspace.categories"
@@ -24,10 +18,8 @@
 <script lang="ts" setup>
   import SaOverviewPage from '@/components/SaOverviewPage.vue';
   import SaPageableItems from '@/components/pageable-items/SaPageableItems.vue';
-  import SaIcon from '@/components/SaIcon.vue';
   import CategoriesOverviewPanel from '@/pages/settings/categories/CategoriesOverviewPanel.vue';
   import { useCurrentWorkspace } from '@/services/workspaces';
-  import useNavigation from '@/services/use-navigation';
   import { graphql } from '@/services/api/gql';
   import { $t } from '@/services/i18n';
 
@@ -56,8 +48,4 @@
 
   const { currentWorkspaceId } = useCurrentWorkspace();
 
-  const { navigateByViewName } = useNavigation();
-  const navigateToNewCategoryView = () => {
-    navigateByViewName('create-new-category');
-  };
 </script>

--- a/frontend/src/pages/settings/categories/Categories.vue
+++ b/frontend/src/pages/settings/categories/Categories.vue
@@ -1,22 +1,14 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ $t.categoriesOverview.header() }}</h1>
-
-      <div class="sa-header-options">
-        <div>
-          <span>{{ $t.categoriesOverview.filters.announcement() }}</span>
-        </div>
-
-        <ElButton
-          round
-          @click="navigateToNewCategoryView"
-        >
-          <SaIcon icon="plus-thin" />
-          {{ $t.categoriesOverview.create() }}
-        </ElButton>
-      </div>
-    </div>
+  <SaOverviewPage :header="$t.categoriesOverview.header()">
+    <template #actions>
+      <ElButton
+        round
+        @click="navigateToNewCategoryView"
+      >
+        <SaIcon icon="plus-thin" />
+        {{ $t.categoriesOverview.create() }}
+      </ElButton>
+    </template>
 
     <SaPageableItems
       :page-query="categoriesPageQuery"
@@ -26,10 +18,11 @@
     >
       <CategoriesOverviewPanel :category="item" />
     </SaPageableItems>
-  </div>
+  </SaOverviewPage>
 </template>
 
 <script lang="ts" setup>
+  import SaOverviewPage from '@/components/SaOverviewPage.vue';
   import SaPageableItems from '@/components/pageable-items/SaPageableItems.vue';
   import SaIcon from '@/components/SaIcon.vue';
   import CategoriesOverviewPanel from '@/pages/settings/categories/CategoriesOverviewPanel.vue';

--- a/frontend/src/pages/settings/categories/EditCategory.vue
+++ b/frontend/src/pages/settings/categories/EditCategory.vue
@@ -1,8 +1,5 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ pageHeader }}</h1>
-    </div>
+  <SaPage :header="pageHeader">
 
     <SaForm v-model="formValues" :on-submit="saveCategory" :on-load="loadCategory" :on-cancel="navigateToCategoriesOverview">
       <SaFormInput prop="name" :label="$t.editCategory.form.name.label()" />
@@ -10,11 +7,12 @@
       <SaFormCheckbox prop="income" :label="$t.editCategory.form.income.label()" />
       <SaFormCheckbox prop="expense" :label="$t.editCategory.form.expense.label()" />
     </SaForm>
-  </div>
+  </SaPage>
 </template>
 
 <script lang="ts" setup>
   import { computed, ref } from 'vue';
+  import SaPage from '@/components/SaPage.vue';
   import SaForm from '@/components/form/SaForm.vue';
   import SaFormInput from '@/components/form/SaFormInput.vue';
   import SaFormCheckbox from '@/components/form/SaFormCheckbox.vue';

--- a/frontend/src/pages/settings/customers/CustomersOverview.vue
+++ b/frontend/src/pages/settings/customers/CustomersOverview.vue
@@ -1,35 +1,18 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ $t.customersOverview.header() }}</h1>
-
-      <div class="sa-header-options">
-        <div>
-          <span>{{ $t.customersOverview.filters.announcement() }}</span>
-        </div>
-
-        <div>
-          <ElInput
-            class="sa-header-options__filter-input"
-            v-model="freeSearchText"
-            :placeholder="$t.customersOverview.filters.input.placeholder()"
-            clearable
-          >
-            <template #prefix>
-              <Search class="sa-header-options__filter-input__icon" />
-            </template>
-          </ElInput>
-        </div>
-
-        <ElButton
-          round
-          @click="navigateToCreateCustomerView"
-        >
-          <SaIcon icon="plus-thin" />
-          {{ $t.customersOverview.create() }}
-        </ElButton>
-      </div>
-    </div>
+  <SaOverviewPage
+    v-model="freeSearchText"
+    :header="$t.customersOverview.header()"
+    :filter-placeholder="$t.customersOverview.filters.input.placeholder()"
+  >
+    <template #actions>
+      <ElButton
+        round
+        @click="navigateToCreateCustomerView"
+      >
+        <SaIcon icon="plus-thin" />
+        {{ $t.customersOverview.create() }}
+      </ElButton>
+    </template>
 
     <SaPageableItems
       :page-query="customersPageQuery"
@@ -39,12 +22,12 @@
     >
       <CustomersOverviewPanel :customer="item" />
     </SaPageableItems>
-  </div>
+  </SaOverviewPage>
 </template>
 
 <script lang="ts" setup>
   import { ref } from 'vue';
-  import { Search } from '@element-plus/icons-vue';
+  import SaOverviewPage from '@/components/SaOverviewPage.vue';
   import SaIcon from '@/components/SaIcon.vue';
   import useNavigation from '@/services/use-navigation';
   import { useCurrentWorkspace } from '@/services/workspaces';

--- a/frontend/src/pages/settings/customers/CustomersOverview.vue
+++ b/frontend/src/pages/settings/customers/CustomersOverview.vue
@@ -3,17 +3,9 @@
     v-model="freeSearchText"
     :header="$t.customersOverview.header()"
     :filter-placeholder="$t.customersOverview.filters.input.placeholder()"
+    :create-action-label="$t.customersOverview.create()"
+    create-action-view-name="create-new-customer"
   >
-    <template #actions>
-      <ElButton
-        round
-        @click="navigateToCreateCustomerView"
-      >
-        <SaIcon icon="plus-thin" />
-        {{ $t.customersOverview.create() }}
-      </ElButton>
-    </template>
-
     <SaPageableItems
       :page-query="customersPageQuery"
       path="workspace.customers"
@@ -28,8 +20,6 @@
 <script lang="ts" setup>
   import { ref } from 'vue';
   import SaOverviewPage from '@/components/SaOverviewPage.vue';
-  import SaIcon from '@/components/SaIcon.vue';
-  import useNavigation from '@/services/use-navigation';
   import { useCurrentWorkspace } from '@/services/workspaces';
   import CustomersOverviewPanel from '@/pages/settings/customers/CustomersOverviewPanel.vue';
   import { $t } from '@/services/i18n';
@@ -55,9 +45,6 @@
       }
     }
   `);
-
-  const { navigateByViewName } = useNavigation();
-  const navigateToCreateCustomerView = () => navigateByViewName('create-new-customer');
 
   const { currentWorkspaceId } = useCurrentWorkspace();
 

--- a/frontend/src/pages/settings/customers/EditCustomer.vue
+++ b/frontend/src/pages/settings/customers/EditCustomer.vue
@@ -1,8 +1,5 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ pageHeader }}</h1>
-    </div>
+  <SaPage :header="pageHeader">
 
     <SaForm v-model="formValues" :on-submit="saveCustomer" :on-load="loadCustomer" :on-cancel="navigateToCustomersOverview">
       <SaFormInput
@@ -11,11 +8,12 @@
         :placeholder="$t.editCustomer.form.name.placeholder()"
       />
     </SaForm>
-  </div>
+  </SaPage>
 </template>
 
 <script lang="ts" setup>
   import { computed, ref } from 'vue';
+  import SaPage from '@/components/SaPage.vue';
   import SaForm from '@/components/form/SaForm.vue';
   import SaFormInput from '@/components/form/SaFormInput.vue';
   import useNavigation from '@/services/use-navigation';

--- a/frontend/src/pages/settings/general-taxes/EditGeneralTax.vue
+++ b/frontend/src/pages/settings/general-taxes/EditGeneralTax.vue
@@ -1,8 +1,5 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ pageHeader }}</h1>
-    </div>
+  <SaPage :header="pageHeader">
 
     <SaForm v-model="formValues" :on-submit="saveTax" :on-load="loadTax" :on-cancel="navigateToTaxesOverview">
       <SaFormInput
@@ -22,11 +19,12 @@
         :placeholder="$t.editGeneralTax.form.rate.placeholder()"
       />
     </SaForm>
-  </div>
+  </SaPage>
 </template>
 
 <script lang="ts" setup>
   import { computed, ref } from 'vue';
+  import SaPage from '@/components/SaPage.vue';
   import SaForm from '@/components/form/SaForm.vue';
   import SaFormInput from '@/components/form/SaFormInput.vue';
   import SaFormNumberInput from '@/components/form/SaFormNumberInput.vue';

--- a/frontend/src/pages/settings/general-taxes/GeneralTaxesOverview.vue
+++ b/frontend/src/pages/settings/general-taxes/GeneralTaxesOverview.vue
@@ -1,35 +1,18 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ $t.generalTaxesOverview.header() }}</h1>
-
-      <div class="sa-header-options">
-        <div>
-          <span>{{ $t.generalTaxesOverview.filters.announcement() }}</span>
-        </div>
-
-        <div>
-          <ElInput
-            class="sa-header-options__filter-input"
-            v-model="freeSearchText"
-            :placeholder="$t.generalTaxesOverview.filters.input.placeholder()"
-            clearable
-          >
-            <template #prefix>
-              <Search class="sa-header-options__filter-input__icon" />
-            </template>
-          </ElInput>
-        </div>
-
-        <ElButton
-          round
-          @click="navigateToCreateTaxView"
-        >
-          <SaIcon icon="plus-thin" />
-          {{ $t.generalTaxesOverview.create() }}
-        </ElButton>
-      </div>
-    </div>
+  <SaOverviewPage
+    v-model="freeSearchText"
+    :header="$t.generalTaxesOverview.header()"
+    :filter-placeholder="$t.generalTaxesOverview.filters.input.placeholder()"
+  >
+    <template #actions>
+      <ElButton
+        round
+        @click="navigateToCreateTaxView"
+      >
+        <SaIcon icon="plus-thin" />
+        {{ $t.generalTaxesOverview.create() }}
+      </ElButton>
+    </template>
 
     <SaPageableItems
       :page-query="generalTaxesPageQuery"
@@ -39,12 +22,12 @@
     >
       <GeneralTaxOverviewPanel :tax="item" />
     </SaPageableItems>
-  </div>
+  </SaOverviewPage>
 </template>
 
 <script lang="ts" setup>
   import { ref } from 'vue';
-  import { Search } from '@element-plus/icons-vue';
+  import SaOverviewPage from '@/components/SaOverviewPage.vue';
   import SaPageableItems from '@/components/pageable-items/SaPageableItems.vue';
   import SaIcon from '@/components/SaIcon.vue';
   import useNavigation from '@/services/use-navigation';

--- a/frontend/src/pages/settings/general-taxes/GeneralTaxesOverview.vue
+++ b/frontend/src/pages/settings/general-taxes/GeneralTaxesOverview.vue
@@ -3,17 +3,9 @@
     v-model="freeSearchText"
     :header="$t.generalTaxesOverview.header()"
     :filter-placeholder="$t.generalTaxesOverview.filters.input.placeholder()"
+    :create-action-label="$t.generalTaxesOverview.create()"
+    create-action-view-name="create-new-general-tax"
   >
-    <template #actions>
-      <ElButton
-        round
-        @click="navigateToCreateTaxView"
-      >
-        <SaIcon icon="plus-thin" />
-        {{ $t.generalTaxesOverview.create() }}
-      </ElButton>
-    </template>
-
     <SaPageableItems
       :page-query="generalTaxesPageQuery"
       path="workspace.generalTaxes"
@@ -29,8 +21,6 @@
   import { ref } from 'vue';
   import SaOverviewPage from '@/components/SaOverviewPage.vue';
   import SaPageableItems from '@/components/pageable-items/SaPageableItems.vue';
-  import SaIcon from '@/components/SaIcon.vue';
-  import useNavigation from '@/services/use-navigation';
   import { useCurrentWorkspace } from '@/services/workspaces';
   import GeneralTaxOverviewPanel from '@/pages/settings/general-taxes/GeneralTaxOverviewPanel.vue';
   import { graphql } from '@/services/api/gql';
@@ -57,9 +47,6 @@
       }
     }
   `);
-
-  const { navigateByViewName } = useNavigation();
-  const navigateToCreateTaxView = () => navigateByViewName('create-new-general-tax');
 
   const { currentWorkspaceId } = useCurrentWorkspace();
 

--- a/frontend/src/pages/settings/workspaces/WorkspaceEditor.vue
+++ b/frontend/src/pages/settings/workspaces/WorkspaceEditor.vue
@@ -1,20 +1,18 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ pageHeader }}</h1>
-    </div>
+  <SaPage :header="pageHeader">
 
     <SaForm v-model="formValues" :on-submit="saveWorkspace" :on-load="loadWorkspaceData" :on-cancel="navigateToWorkspacesOverview">
       <h2>{{ $t.workspaceEditor.generalInformation.header() }}</h2>
       <SaFormInput prop="name" :label="$t.workspaceEditor.generalInformation.workspaceName.label()" />
       <SaFormCurrencyInput prop="defaultCurrency" :label="$t.workspaceEditor.generalInformation.defaultCurrency.label()" :disabled="isEditing" />
     </SaForm>
-  </div>
+  </SaPage>
 </template>
 
 <script lang="ts" setup>
   import { ref } from 'vue';
   import { $t } from '@/services/i18n';
+  import SaPage from '@/components/SaPage.vue';
   import SaForm from '@/components/form/SaForm.vue';
   import SaFormInput from '@/components/form/SaFormInput.vue';
   import SaFormCurrencyInput from '@/components/form/SaFormCurrencyInput.vue';

--- a/frontend/src/pages/settings/workspaces/WorkspacesOverview.vue
+++ b/frontend/src/pages/settings/workspaces/WorkspacesOverview.vue
@@ -1,15 +1,9 @@
 <template>
-  <SaOverviewPage :header="$t.workspacesOverview.header()">
-    <template #actions>
-      <ElButton
-        round
-        @click="navigateToCreateWorkspace"
-      >
-        <SaIcon icon="plus-thin" />
-        {{ $t.workspacesOverview.create() }}
-      </ElButton>
-    </template>
-
+  <SaOverviewPage
+    :header="$t.workspacesOverview.header()"
+    :create-action-label="$t.workspacesOverview.create()"
+    create-action-view-name="create-new-workspace"
+  >
     <SaPageableItems
       ref="pageableItems"
       :page-query="workspacesPageQuery"
@@ -23,8 +17,6 @@
 
 <script lang="ts" setup>
   import SaOverviewPage from '@/components/SaOverviewPage.vue';
-  import SaIcon from '@/components/SaIcon.vue';
-  import useNavigation from '@/services/use-navigation';
   import WorkspacesOverviewItemPanel from '@/pages/settings/workspaces/WorkspacesOverviewItemPanel.vue';
   import { graphql } from '@/services/api/gql';
   import SaPageableItems from '@/components/pageable-items/SaPageableItems.vue';
@@ -49,6 +41,4 @@
     }
   `);
 
-  const { navigateByViewName } = useNavigation();
-  const navigateToCreateWorkspace = () => navigateByViewName('create-new-workspace');
 </script>

--- a/frontend/src/pages/settings/workspaces/WorkspacesOverview.vue
+++ b/frontend/src/pages/settings/workspaces/WorkspacesOverview.vue
@@ -1,20 +1,14 @@
 <template>
-  <div>
-    <div class="sa-page-header">
-      <h1>{{ $t.workspacesOverview.header() }}</h1>
-
-      <div class="sa-header-options">
-        <span />
-
-        <ElButton
-          round
-          @click="navigateToCreateWorkspace"
-        >
-          <SaIcon icon="plus-thin" />
-          {{ $t.workspacesOverview.create() }}
-        </ElButton>
-      </div>
-    </div>
+  <SaOverviewPage :header="$t.workspacesOverview.header()">
+    <template #actions>
+      <ElButton
+        round
+        @click="navigateToCreateWorkspace"
+      >
+        <SaIcon icon="plus-thin" />
+        {{ $t.workspacesOverview.create() }}
+      </ElButton>
+    </template>
 
     <SaPageableItems
       ref="pageableItems"
@@ -24,10 +18,11 @@
     >
       <WorkspacesOverviewItemPanel :workspace="item" />
     </SaPageableItems>
-  </div>
+  </SaOverviewPage>
 </template>
 
 <script lang="ts" setup>
+  import SaOverviewPage from '@/components/SaOverviewPage.vue';
   import SaIcon from '@/components/SaIcon.vue';
   import useNavigation from '@/services/use-navigation';
   import WorkspacesOverviewItemPanel from '@/pages/settings/workspaces/WorkspacesOverviewItemPanel.vue';

--- a/frontend/src/services/i18n/t9n/en.ts
+++ b/frontend/src/services/i18n/t9n/en.ts
@@ -24,6 +24,12 @@ export default {
     save: () => 'Save',
   },
 
+  overviewPage: {
+    filters: {
+      announcement: () => 'Filters coming soon',
+    },
+  },
+
   loginPage: {
     announcement: () => 'New here? We are launching public access soon.',
     userName: {
@@ -289,7 +295,6 @@ export default {
   expensesOverview: {
     header: () => 'Expenses',
     filters: {
-      announcement: () => 'Filters coming soon',
       input: {
         placeholder: () => 'Search expenses',
       },
@@ -356,17 +361,11 @@ export default {
 
   incomeTaxPaymentsOverview: {
     header: () => 'Income Tax Payments',
-    filters: {
-      announcement: () => 'Filters coming soon',
-    },
     create: () => 'Add new',
   },
 
   documentsOverview: {
     header: () => 'Documents',
-    filters: {
-      announcement: () => 'Filters coming soon',
-    },
     create: () => 'Upload',
   },
 
@@ -646,7 +645,6 @@ export default {
   incomesOverview: {
     header: () => 'Incomes',
     filters: {
-      announcement: () => 'Filters coming soon',
       input: {
         placeholder: () => 'Search incomes',
       },
@@ -738,7 +736,6 @@ export default {
   invoicesOverview: {
     header: () => 'Invoices',
     filters: {
-      announcement: () => 'Filters coming soon',
       input: {
         placeholder: () => 'Search invoices',
       },
@@ -964,7 +961,6 @@ export default {
   usersOverview: {
     header: () => 'Users',
     filters: {
-      announcement: () => 'Filters coming soon',
       input: {
         placeholder: () => 'Search users',
       },
@@ -1145,9 +1141,6 @@ export default {
 
   categoriesOverview: {
     header: () => 'Categories',
-    filters: {
-      announcement: () => 'Filters coming soon',
-    },
     create: () => 'Add new',
     edit: () => 'Edit',
     type: {
@@ -1193,7 +1186,6 @@ export default {
   generalTaxesOverview: {
     header: () => 'General Taxes',
     filters: {
-      announcement: () => 'Filters coming soon',
       input: {
         placeholder: () => 'Search general taxes',
       },
@@ -1226,7 +1218,6 @@ export default {
   customersOverview: {
     header: () => 'Customers',
     filters: {
-      announcement: () => 'Filters coming soon',
       input: {
         placeholder: () => 'Search customers',
       },

--- a/frontend/src/services/i18n/t9n/uk.ts
+++ b/frontend/src/services/i18n/t9n/uk.ts
@@ -24,6 +24,12 @@ export default {
     save: () => 'Зберегти',
   },
 
+  overviewPage: {
+    filters: {
+      announcement: () => 'Фільтри будуть незабаром',
+    },
+  },
+
   loginPage: {
     announcement: () => 'Вперше тут? Ми запускаємо публічний доступ скоро.',
     userName: {
@@ -289,7 +295,6 @@ export default {
   expensesOverview: {
     header: () => 'Витрати',
     filters: {
-      announcement: () => 'Фільтри будуть незабаром',
       input: {
         placeholder: () => 'Витрати на пошук ',
       },
@@ -355,17 +360,11 @@ export default {
 
   incomeTaxPaymentsOverview: {
     header: () => 'Прибутковий Податок ',
-    filters: {
-      announcement: () => 'Фільтри будуть незабаром',
-    },
     create: () => 'Додати новий',
   },
 
   documentsOverview: {
     header: () => 'Документи',
-    filters: {
-      announcement: () => 'Фільтри будуть незабаром',
-    },
     create: () => 'Завантажити',
   },
 
@@ -645,7 +644,6 @@ export default {
   incomesOverview: {
     header: () => 'Доходи',
     filters: {
-      announcement: () => 'Фільтри будуть незабаром',
       input: {
         placeholder: () => 'Пошук доходи ',
       },
@@ -737,7 +735,6 @@ export default {
   invoicesOverview: {
     header: () => 'Рахунки-фактури',
     filters: {
-      announcement: () => 'Фільтри будуть незабаром',
       input: {
         placeholder: () => 'Пошук рахунків-фактур',
       },
@@ -963,7 +960,6 @@ export default {
   usersOverview: {
     header: () => 'Користувачі',
     filters: {
-      announcement: () => 'Фільтри будуть незабаром',
       input: {
         placeholder: () => 'Пошук користувачів',
       },
@@ -1144,9 +1140,6 @@ export default {
 
   categoriesOverview: {
     header: () => 'Категорії',
-    filters: {
-      announcement: () => 'Фільтри незабаром',
-    },
     create: () => 'Додати новий',
     edit: () => 'Редагувати',
     type: {
@@ -1192,7 +1185,6 @@ export default {
   generalTaxesOverview: {
     header: () => 'Загальні податки',
     filters: {
-      announcement: () => 'Фільтри незабаром',
       input: {
         placeholder: () => 'Шукати загальні податки',
       },
@@ -1225,7 +1217,6 @@ export default {
   customersOverview: {
     header: () => 'Клієнти',
     filters: {
-      announcement: () => 'Фільтри незабаром',
       input: {
         placeholder: () => 'Шукати клієнтів',
       },

--- a/frontend/src/styles/main.scss
+++ b/frontend/src/styles/main.scss
@@ -20,46 +20,6 @@ body {
   color: $secondary-text-color;
 }
 
-.sa-page-header {
-  h1 {
-    margin-top: 0;
-    margin-bottom: 10px;
-    font-size: 160%;
-  }
-
-  &:after {
-    content: "";
-    display: block;
-    width: 100%;
-    height: 1px;
-    margin-top: 10px;
-    margin-bottom: 30px;
-    background: $secondary-grey;
-  }
-
-  .sa-header-options {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-
-    &__filter-input {
-      .el-input__wrapper {
-        background-color: transparent;
-        border: none;
-        box-shadow: none;
-        color: $secondary-text-color;
-        max-width: 200px;
-      }
-
-      &__icon {
-        width: 16px;
-        height: 16px;
-      }
-    }
-
-  }
-}
-
 h2 {
   font-size: 140%;
 }


### PR DESCRIPTION
## Problem statement

UI pages duplicated the same page wrapper and header structure, which made shared layout changes brittle and inconsistent.

## Solution summary

Introduce shared `SaPage` and `SaOverviewPage` components, migrate standard pages to them, centralize the standard overview create action and shared overview announcement, and update affected UI tests to the new page structure.

## Notes

Validation was completed before this workflow. One unrelated full-stack test remained flaky outside the page-layout selector fix path during local reruns.
