### PR TITLE
fix(frontend): avoid document upload reset flicker

### DIFF
--- a/.agents/skills/simple-accounting-pull-request/SKILL.md
+++ b/.agents/skills/simple-accounting-pull-request/SKILL.md
@@ -15,7 +15,7 @@ This workflow is intentionally local and stateful. It may create commits, rebase
 
 ## Context Requirement
 
-Before deciding commit metadata, PR metadata, validation statements, or remediation actions, account for the full available conversation and session context. Do not rely only on the user's last turn.
+Before deciding commit metadata, PR metadata, or remediation actions, account for the full available conversation and session context. Do not rely only on the user's last turn.
 
 The full context includes:
 
@@ -107,7 +107,7 @@ PR description rules:
 
 - Summarize the user-visible or maintainer-visible change.
 - Do not include validation, testing, linting, compilation, CI, or build statements in the PR description.
-- If the template has a validation or testing section, keep it empty or mark it as `N/A` without adding details.
+- If the template has a validation or testing section, leave it empty. Do not write `N/A`, commands, prior results, skipped validation, CI status, or any other validation-related text in the PR description.
 - Keep the description factual and concise.
 
 ### 3. Commit Pending Changes
@@ -296,7 +296,6 @@ Report the result with these fields:
 - Auto-merge: enabled with squash, already merged, or not enabled with the reason.
 - CI: passed, still pending, or failed with the unresolved reason.
 - Base: `origin/master` commit used for the rebase.
-- Validation: state that pre-PR validation was not run by this workflow, mention prior validation only if known from full session context, and mention any local validation run while fixing CI failures.
 
 Keep the report short and factual.
 

--- a/.agents/skills/simple-accounting-pull-request/SKILL.md
+++ b/.agents/skills/simple-accounting-pull-request/SKILL.md
@@ -3,7 +3,7 @@ name: simple-accounting-pull-request
 description: >
   Publishes the current local branch to remote, creates a pull request against
   master, and enables squash auto-merge after committing pending changes,
-  rebasing onto origin/master, and force-pushing safely.
+  rebasing onto origin/master, force-pushing safely, and waiting for PR CI.
 compatibility: "requires: gh CLI, git, repository write access"
 ---
 
@@ -11,7 +11,21 @@ compatibility: "requires: gh CLI, git, repository write access"
 
 Use this skill when the user wants to publish the current local branch, commit pending changes, create a GitHub pull request, or enable auto-merge for a branch.
 
-This workflow is intentionally local and stateful. It may create commits, rebase the current branch, force-push with lease, create a pull request, and enable squash auto-merge. Only use it when the user explicitly requests this publish-and-PR workflow or an equivalent operation.
+This workflow is intentionally local and stateful. It may create commits, rebase the current branch, force-push with lease, create a pull request, enable squash auto-merge, wait for PR CI, and fix CI failures. Only use it when the user explicitly requests this publish-and-PR workflow or an equivalent operation.
+
+## Context Requirement
+
+Before deciding commit metadata, PR metadata, validation statements, or remediation actions, account for the full available conversation and session context. Do not rely only on the user's last turn.
+
+The full context includes:
+
+- The original user request and any later refinements.
+- All code changes made during the session, including generated files.
+- Validation already run, skipped, failed, or fixed earlier in the conversation.
+- Constraints, decisions, and tradeoffs discussed before the PR workflow was invoked.
+- Any known issue references, branch purpose, or release context mentioned earlier.
+
+If the full conversation context is insufficient to write accurate metadata or decide a safe remediation, ask the user or perform the necessary inspection. Do not guess from the latest turn alone.
 
 ## Preconditions
 
@@ -68,9 +82,9 @@ When there are pending changes:
 
 ### 2. Define Commit Message, PR Title, and PR Description
 
-Use the current conversation and session context to define the commit message, PR title, and PR description. Do not perform a full branch-scope review by default; it can be too expensive and duplicates work expected from previous actors.
+Use the full conversation and session context to define the commit message, PR title, and PR description. Do not perform a full branch-scope review by default; it can be too expensive and duplicates work expected from previous actors.
 
-If the session context is insufficient to write accurate metadata, ask the user whether they want you to execute a full branch review before continuing. Do not guess.
+If the full context is insufficient to write accurate metadata, ask the user whether they want you to execute a full branch review before continuing. Do not guess.
 
 Use the repository guidelines:
 
@@ -87,12 +101,13 @@ Inspect the pull request template:
 git ls-files docs/pull_request_template.md
 ```
 
-If the template exists, read it and use its sections exactly. Fill unavailable sections with concise, honest values such as `N/A` only when appropriate. Do not invent issue links, test results, or product impact.
+If the template exists, read it and use its sections exactly. Fill unavailable sections with concise, honest values such as `N/A` only when appropriate. Do not invent issue links or product impact.
 
 PR description rules:
 
 - Summarize the user-visible or maintainer-visible change.
-- Do not run validation commands as part of this skill. Tests, linting, compilation, and similar checks are the responsibility of previous actors before invoking this workflow. Do no state validation in the PR description.
+- Do not include validation, testing, linting, compilation, CI, or build statements in the PR description.
+- If the template has a validation or testing section, keep it empty or mark it as `N/A` without adding details.
 - Keep the description factual and concise.
 
 ### 3. Commit Pending Changes
@@ -179,7 +194,7 @@ Before creating a PR, check whether one already exists for the branch:
 gh pr list --head "$current_branch" --json number,title,url,state,isDraft
 ```
 
-If an open PR already exists for this branch, do not create a duplicate. Update the existing PR title and description using the metadata defined from the session context:
+If an open PR already exists for this branch, do not create a duplicate. Update the existing PR title and description using the metadata defined from the full session context:
 
 ```bash
 gh pr edit "$pr_number" \
@@ -223,7 +238,38 @@ Rules:
 - If auto-merge cannot be enabled because repository settings disallow it, report that clearly and leave the PR open.
 - If required checks are pending, auto-merge should remain enabled and GitHub will merge after requirements pass.
 
-### 9. Verify Final State
+### 9. Wait For PR CI
+
+Wait for the pull request's CI checks to complete after auto-merge is enabled:
+
+```bash
+gh pr checks "$pr_number" --watch
+```
+
+If all required checks pass, continue to the final state verification.
+
+If any CI check fails:
+
+- Disable auto-merge before making changes:
+
+```bash
+gh pr merge "$pr_number" --disable-auto
+```
+
+- Inspect the failed check details with `gh pr checks "$pr_number"`, `gh run view`, or `gh run view --log-failed` as appropriate.
+- Investigate the root cause locally, using the full conversation context and the failed CI output.
+- Fix only issues that are necessary for CI to pass and are consistent with the branch's intended scope.
+- Run the smallest relevant local validation for the fix, following the repository validation workflow.
+- Commit the fix with a normal Conventional Commit message. Do not amend unless the user explicitly requested it.
+- Rebase onto the latest `origin/master` again if needed.
+- Push with `--force-with-lease`.
+- Wait for PR CI again.
+- Repeat this investigate/fix/push/wait loop until CI passes or until blocked by an unclear failure that requires user input.
+- Leave auto-merge disabled after pushing any CI fix. The user must verify the fix and merge manually later.
+
+Do not leave auto-merge enabled while pushing a fix for failed CI. Do not re-enable auto-merge after a CI failure has required a fix.
+
+### 10. Verify Final State
 
 Collect final status:
 
@@ -236,9 +282,10 @@ Use this information in the final response.
 
 ## Validation
 
-Do not run tests, linting, compilation, builds, schema generation, GraphQL code generation, or other validation commands as part of this skill.
+Do not run tests, linting, compilation, builds, schema generation, GraphQL code generation, or other validation commands before creating the PR as part of this skill.
 
-Assume validation and generated artifacts were handled by previous actors before this publish workflow was invoked.
+Assume validation and generated artifacts were handled by previous actors before this publish workflow was invoked. The exception is CI failure remediation after the PR exists: in that case, run the smallest relevant local validation needed to confirm the fix before pushing.
+
 ## Final Report
 
 Report the result with these fields:
@@ -247,8 +294,9 @@ Report the result with these fields:
 - Branch: current branch name.
 - Pull request: PR URL.
 - Auto-merge: enabled with squash, already merged, or not enabled with the reason.
+- CI: passed, still pending, or failed with the unresolved reason.
 - Base: `origin/master` commit used for the rebase.
-- Validation: state that validation was not run by this workflow, and mention prior validation only if known from session context.
+- Validation: state that pre-PR validation was not run by this workflow, mention prior validation only if known from full session context, and mention any local validation run while fixing CI failures.
 
 Keep the report short and factual.
 
@@ -257,9 +305,10 @@ Keep the report short and factual.
 - If GitHub CLI auth fails, stop and tell the user to run `gh auth login`.
 - If the branch is `master`, stop and tell the user this workflow requires a feature branch.
 - If likely secret files are pending, stop and ask before staging them.
-- If the session context is insufficient for accurate commit or PR metadata, ask whether to perform a full branch review before continuing.
+- If the full conversation context is insufficient for accurate commit or PR metadata, ask whether to perform a full branch review before continuing.
 - If rebase conflicts are unclear, stop and ask the user how to resolve them.
 - If `git push --force-with-lease` fails, do not retry with plain `--force`; fetch and inspect remote divergence.
 - If PR creation fails, report the exact `gh` error and provide the `gh pr create ...` command for retry.
 - If auto-merge fails, leave the PR open and report the exact reason.
+- If CI fails after auto-merge is enabled, disable auto-merge, investigate, fix, push, wait again until CI passes or user input is required, and leave auto-merge disabled for the user to verify and merge manually.
 - Never delete branches, reset history, or force-push `master`.

--- a/frontend/src/components/documents/SaDocumentsUpload.vue
+++ b/frontend/src/components/documents/SaDocumentsUpload.vue
@@ -246,7 +246,9 @@
       storageActive: true,
     };
 
-    if (documentsStorageStatus.value.loading || checkingDownloadStorages.value) {
+    if (!documentsStorageStatus.value.loaded
+      || documentsStorageStatus.value.loading
+      || checkingDownloadStorages.value) {
       state.initialLoading = true;
     } else if (!uploadStorageActive.value) {
       state.storageActive = false;

--- a/frontend/src/components/documents/storage/useDocumentsStorageStatus.ts
+++ b/frontend/src/components/documents/storage/useDocumentsStorageStatus.ts
@@ -6,6 +6,7 @@ import { useLazyQuery } from '@/services/api/use-gql-api.ts';
 
 interface DocumentStorageStatusState {
   readonly loading: boolean,
+  readonly loaded: boolean,
   readonly active: boolean,
 }
 
@@ -20,7 +21,7 @@ interface DocumentsStorageStatusProvider {
   readonly downloadStoragesStatus: ComputedRef<DownloadDocumentStoragesState>,
   ensureUploadStorageStatusLoaded: () => Promise<void>,
   ensureDownloadStoragesLoaded: () => Promise<void>,
-  reset: () => void,
+  resetOnNextUse: () => void,
 }
 
 const DocumentsStorageStatusProviderKey = Symbol('DocumentsStorageStatusProvider') as
@@ -54,6 +55,7 @@ function createDocumentsStorageStatusProvider(): DocumentsStorageStatusProvider 
   `), 'getDownloadDocumentStorages');
 
   const generation = ref(0);
+  let resetPending = false;
 
   const uploadStorageLoading = ref(false);
   const uploadStorageLoaded = ref(false);
@@ -67,6 +69,7 @@ function createDocumentsStorageStatusProvider(): DocumentsStorageStatusProvider 
 
   const uploadStorageStatus = computed<DocumentStorageStatusState>(() => ({
     loading: uploadStorageLoading.value,
+    loaded: uploadStorageLoaded.value,
     active: uploadStorageActive.value,
   }));
 
@@ -76,7 +79,30 @@ function createDocumentsStorageStatusProvider(): DocumentsStorageStatusProvider 
     ids: downloadStorageIds.value,
   }));
 
+  const reset = () => {
+    generation.value += 1;
+
+    uploadStorageLoading.value = false;
+    uploadStorageLoaded.value = false;
+    uploadStorageActive.value = false;
+    uploadStorageLoadingPromise = undefined;
+
+    downloadStoragesLoading.value = false;
+    downloadStoragesLoaded.value = false;
+    downloadStorageIds.value = new Set();
+    downloadStoragesLoadingPromise = undefined;
+  };
+
+  const resetIfPending = () => {
+    if (resetPending) {
+      resetPending = false;
+      reset();
+    }
+  };
+
   const ensureUploadStorageStatusLoaded = async () => {
+    resetIfPending();
+
     if (uploadStorageLoaded.value) {
       return;
     }
@@ -110,6 +136,8 @@ function createDocumentsStorageStatusProvider(): DocumentsStorageStatusProvider 
   };
 
   const ensureDownloadStoragesLoaded = async () => {
+    resetIfPending();
+
     if (downloadStoragesLoaded.value) {
       return;
     }
@@ -142,26 +170,14 @@ function createDocumentsStorageStatusProvider(): DocumentsStorageStatusProvider 
     await downloadStoragesLoadingPromise;
   };
 
-  const reset = () => {
-    generation.value += 1;
-
-    uploadStorageLoading.value = false;
-    uploadStorageLoaded.value = false;
-    uploadStorageActive.value = false;
-    uploadStorageLoadingPromise = undefined;
-
-    downloadStoragesLoading.value = false;
-    downloadStoragesLoaded.value = false;
-    downloadStorageIds.value = new Set();
-    downloadStoragesLoadingPromise = undefined;
-  };
-
   return {
     uploadStorageStatus,
     downloadStoragesStatus,
     ensureUploadStorageStatusLoaded,
     ensureDownloadStoragesLoaded,
-    reset,
+    resetOnNextUse: () => {
+      resetPending = true;
+    },
   };
 }
 
@@ -178,7 +194,7 @@ export function provideDocumentsStorageStatus() {
 }
 
 export function resetDocumentsStorageStatus() {
-  activeProvider?.reset();
+  activeProvider?.resetOnNextUse();
 }
 
 export function useDocumentsUploadStorageStatus() {


### PR DESCRIPTION
## Problem statement

Document upload pages could briefly render an incorrect storage failure/loading state while navigating away. The PR creation skill also needed clearer workflow rules based on the full conversation context and PR CI handling.

## Solution summary

Document storage status reset is now deferred until the next document-storage consumer uses it, preventing the page being left from reacting during navigation. The PR creation skill now emphasizes full-context metadata, excludes validation details from PR descriptions, waits for PR CI, and leaves auto-merge disabled after CI fixes.

## Notes

Auto-merge is intentionally not re-enabled after CI failure remediation so the user can verify fixes and merge manually.
