### PR TITLE
fix(frontend): ignore upload teardown errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,10 +422,10 @@ val preconditions = preconditions {
 Full stack tests verify the complete integration between frontend and backend components using Playwright for browser
 automation. These tests should follow the Page Object pattern for maintainable and reusable test code.
 
-#### Playwright Clock and Time
+#### Playwright Time
 
-Full stack tests install Playwright's mock clock and set the browser time to `1999-03-28T23:01:02.042Z` (`MOCK_TIME`).
-The clock is not paused; timers continue to run from that fixed starting point.
+Full stack tests set the browser time to `1999-03-28T23:01:02.042Z` (`MOCK_TIME`) as the starting point.
+Timers continue to run normally from that fixed starting point. Do not advance time manually in tests.
 
 #### Full Stack Test Debugging
 

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/shared/components/SaDocumentsUploadFullStackTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/shared/components/SaDocumentsUploadFullStackTest.kt
@@ -10,8 +10,10 @@ import io.orangebuffalo.simpleaccounting.business.ui.user.expenses.EditExpensePa
 import io.orangebuffalo.simpleaccounting.business.ui.user.expenses.ExpensesOverviewPage.Companion.shouldBeExpensesOverviewPage
 import io.orangebuffalo.simpleaccounting.tests.infra.ui.TestDocumentsStorage
 import io.orangebuffalo.simpleaccounting.tests.infra.ui.components.DocumentsUpload
+import io.orangebuffalo.simpleaccounting.tests.infra.ui.components.shouldHaveSideMenu
 import io.orangebuffalo.simpleaccounting.tests.infra.utils.MOCK_TIME
 import io.orangebuffalo.simpleaccounting.tests.infra.utils.findSingle
+import io.orangebuffalo.simpleaccounting.tests.infra.utils.shouldHaveNotifications
 import io.orangebuffalo.simpleaccounting.tests.infra.utils.shouldWithClue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -291,6 +293,37 @@ class SaDocumentsUploadFullStackTest : SaFullStackTestBase() {
         // Verify uploaded content matches original (binary equality)
         val uploadedContent = testDocumentsStorage.getUploadedContent(savedDocument.storageLocation!!)
         uploadedContent.shouldBe(fileContent)
+    }
+
+    @Test
+    fun `should not show technical error when leaving page with selected file not submitted`(page: Page) {
+        val preconditions = preconditions {
+            object {
+                val fry = platformUser(userName = "Fry", documentsStorage = TestDocumentsStorage.STORAGE_ID)
+                val expense = expense(workspace = workspace(owner = fry))
+            }
+        }
+        val testFile = createTestFile("slurm-receipt.pdf", "Selected but not submitted".toByteArray())
+
+        page.authenticateViaCookie(preconditions.fry)
+        page.navigate("/expenses/${preconditions.expense.id}/edit")
+
+        page.shouldBeEditExpensePage {
+            documentsUpload {
+                shouldHaveDocuments(DocumentsUpload.EmptyDocument)
+                selectFileForUpload(testFile)
+                shouldHaveDocuments(
+                    DocumentsUpload.UploadedDocument(testFile.name, DocumentsUpload.DocumentState.PENDING),
+                    DocumentsUpload.EmptyDocument
+                )
+            }
+        }
+
+        page.shouldHaveSideMenu().clickDashboard()
+
+        page.shouldHaveNotifications {
+            shouldHaveNoNotifications()
+        }
     }
 
     @Test

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/tests/infra/ui/FullStackTestsEnvironment.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/tests/infra/ui/FullStackTestsEnvironment.kt
@@ -61,11 +61,11 @@ fun createConfiguredBrowserContext(
 }
 
 /**
- * Creates a new page in the given browser context with mock clock installed.
+ * Creates a new page in the given browser context with the standard test start time.
  * Tests creating custom pages can use this to set up pages consistently.
  * 
  * @param context The browser context to create the page in
- * @return A new page with mock clock installed
+ * @return A new page with the standard test start time
  */
 fun createNewPage(context: BrowserContext): Page {
     val page = context.newPage()
@@ -229,7 +229,7 @@ private class IsolatedPageContextStrategy(
     override fun getPageForTheTest(): Page {
         if (page == null) {
             page = browserContext!!.newPage()
-            // Install mock clock at fixed time but keep it running
+            // Set the browser time to the standard test starting point.
             page!!.clock().install(Clock.InstallOptions().setTime(MOCK_TIME.toEpochMilli()))
             page!!.clock().setSystemTime(MOCK_TIME.toEpochMilli())
         }
@@ -298,7 +298,7 @@ private class PersistentPageContextStrategy(
             )
             configureNewBrowserContext(browserContext!!)
             page = browserContext!!.newPage()
-            // Install mock clock at fixed time but keep it running
+            // Set the browser time to the standard test starting point.
             page!!.clock().install(Clock.InstallOptions().setTime(MOCK_TIME.toEpochMilli()))
             page!!.clock().setSystemTime(MOCK_TIME.toEpochMilli())
         }

--- a/frontend/src/components/documents/SaDocumentUpload.vue
+++ b/frontend/src/components/documents/SaDocumentUpload.vue
@@ -135,6 +135,7 @@
   const maxFileSize = 50 * 1024 * 1024;
   const dropPanel = ref<HTMLElement | undefined>(undefined);
   let dropzone: Dropzone | undefined;
+  let unmounting = false;
   const dropzoneRequired = () => {
     if (!dropzone) throw new Error('Not initialized yet');
     return dropzone;
@@ -169,6 +170,9 @@
       });
 
       dropzone.on('error', (file, error) => {
+        if (unmounting) {
+          return;
+        }
         // todo #72: special processing for storage service config error
         uploading.value = false;
         uploadingFailed.value = true;
@@ -186,6 +190,7 @@
 
   onBeforeUnmount(() => {
     if (dropzone) {
+      unmounting = true;
       dropzone.destroy();
       dropzone = undefined;
     }


### PR DESCRIPTION
## Problem statement

Navigating away after selecting a document for upload could show a fatal technical error notification.

## Solution summary

Ignore Dropzone error events emitted while the upload component is unmounting, and cover the navigation-away scenario with a full-stack reproducer.

## Notes

Also clarifies full-stack test time comments to avoid implying tests should manually advance time.
