### PR TITLE
tests: Stabilize workspace creation full stack test

### DIFF
--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/workspaces/CreateWorkspaceFullStackTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/workspaces/CreateWorkspaceFullStackTest.kt
@@ -26,7 +26,9 @@ class CreateWorkspaceFullStackTest : SaFullStackTestBase() {
             saveButton.click()
         }
 
-        page.shouldBeWorkspacesOverviewPage()
+        page.shouldBeWorkspacesOverviewPage {
+            shouldHaveWorkspaces("Planet Express", "Mom's Friendly Robot Company")
+        }
 
         val newWorkspace = aggregateTemplate.findAll<Workspace>()
             .single { it.name == "Mom's Friendly Robot Company" }


### PR DESCRIPTION
## Problem statement

The workspace creation full stack test can assert database state before the overview page finishes loading its workspace data.

## Solution summary

Wait for the newly created workspace to be rendered on the Workspaces overview before checking persisted database state.

## Notes

N/A
