### PR TITLE
fix(frontend): Keep empty amount fields blank

### DIFF
--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/shared/components/SaMoneyInputFullStackTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/shared/components/SaMoneyInputFullStackTest.kt
@@ -235,6 +235,31 @@ class SaMoneyInputFullStackTest : SaFullStackTestBase() {
     }
 
     @Test
+    fun `should render null amount as empty input`(page: Page) {
+        val preconditions = preconditions {
+            object {
+                val fry = fry()
+                val workspace = workspace(owner = fry, defaultCurrency = "USD")
+                val expense = expense(
+                    workspace = workspace,
+                    category = null,
+                    title = "Delivery to Mars",
+                    originalAmount = 567890,
+                    currency = "EUR",
+                    convertedAmounts = emptyAmountsInDefaultCurrency()
+                )
+            }
+        }
+
+        page.authenticateViaCookie(preconditions.fry)
+        page.navigate("/expenses/${preconditions.expense.id}/edit")
+        page.shouldBeEditExpensePage {
+            convertedAmountInDefaultCurrency("USD").input.shouldHaveValue("")
+            convertedAmountInDefaultCurrency("USD").input.shouldHaveCurrency("USD")
+        }
+    }
+
+    @Test
     fun `should handle large numbers with thousands separators`(page: Page) {
         val preconditions = preconditions {
             object {

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/expenses/ExpensesOverviewFullStackTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/expenses/ExpensesOverviewFullStackTest.kt
@@ -792,7 +792,7 @@ class ExpensesOverviewFullStackTest : SaFullStackTestBase() {
             }
 
             convertedAmountInDefaultCurrency("USD").shouldBeVisible()
-            convertedAmountInDefaultCurrency("USD").input.shouldHaveValue("0.00")
+            convertedAmountInDefaultCurrency("USD").input.shouldHaveValue("")
 
             useDifferentExchangeRateForIncomeTaxPurposes().shouldNotBeChecked()
             incomeTaxableAmountInDefaultCurrency("USD").shouldBeHidden()

--- a/frontend/src/components/SaMoneyInput.vue
+++ b/frontend/src/components/SaMoneyInput.vue
@@ -26,7 +26,7 @@
   import { getCurrencyInfo, getNumbersInfo } from '@/services/i18n';
 
   const props = defineProps<{
-    modelValue?: number,
+    modelValue?: number | null,
     currency: string
   }>();
   const emit = defineEmits<{(e: 'update:modelValue', value?: number): void }>();
@@ -41,7 +41,7 @@
 
   const setMaskValue = () => {
     if (mask) {
-      if (props.modelValue === undefined) {
+      if (props.modelValue == null) {
         mask.value = '';
       } else {
         mask.typedValue = props.modelValue / digitsMultiplier;

--- a/frontend/src/components/form/SaFormMoneyInput.vue
+++ b/frontend/src/components/form/SaFormMoneyInput.vue
@@ -17,5 +17,5 @@
     currency: string,
   }>();
 
-  const inputValue = ref<number | undefined>(undefined);
+  const inputValue = ref<number | null | undefined>(undefined);
 </script>


### PR DESCRIPTION
## Problem statement

Money inputs in edit/create forms rendered nullable amount values as zero, which made blank amount fields appear pre-filled.

## Solution summary

Updated the shared money input to treat null and undefined as empty values, and adjusted full-stack coverage for nullable amount rendering and cloned expense defaults.

## Notes

No issue reference provided.
