### PR TITLE
feat(documents): Add document pagination filters

### DIFF
--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/documents/DocumentUsageFilterType.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/documents/DocumentUsageFilterType.kt
@@ -24,12 +24,3 @@ enum class DocumentUsageFilterType {
     @GraphQLDescription("Document is not used by any entity.")
     UNUSED,
 }
-
-fun DocumentUsageFilterType.toDocumentUsageType(): DocumentUsageType? = when (this) {
-    DocumentUsageFilterType.EXPENSE -> DocumentUsageType.EXPENSE
-    DocumentUsageFilterType.INCOME -> DocumentUsageType.INCOME
-    DocumentUsageFilterType.INVOICE -> DocumentUsageType.INVOICE
-    DocumentUsageFilterType.INCOME_TAX_PAYMENT -> DocumentUsageType.INCOME_TAX_PAYMENT
-    DocumentUsageFilterType.STANDALONE_DOCUMENT -> DocumentUsageType.STANDALONE_DOCUMENT
-    DocumentUsageFilterType.UNUSED -> null
-}

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/documents/DocumentUsageFilterType.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/documents/DocumentUsageFilterType.kt
@@ -1,0 +1,35 @@
+package io.orangebuffalo.simpleaccounting.business.api.documents
+
+import com.expediagroup.graphql.generator.annotations.GraphQLDescription
+import com.expediagroup.graphql.generator.annotations.GraphQLName
+
+@GraphQLName("DocumentUsageFilterType")
+@GraphQLDescription("Usage type filter for documents.")
+enum class DocumentUsageFilterType {
+    @GraphQLDescription("Document is used by an expense.")
+    EXPENSE,
+
+    @GraphQLDescription("Document is used by an income.")
+    INCOME,
+
+    @GraphQLDescription("Document is used by an invoice.")
+    INVOICE,
+
+    @GraphQLDescription("Document is used by an income tax payment.")
+    INCOME_TAX_PAYMENT,
+
+    @GraphQLDescription("Document is used by a standalone document.")
+    STANDALONE_DOCUMENT,
+
+    @GraphQLDescription("Document is not used by any entity.")
+    UNUSED,
+}
+
+fun DocumentUsageFilterType.toDocumentUsageType(): DocumentUsageType? = when (this) {
+    DocumentUsageFilterType.EXPENSE -> DocumentUsageType.EXPENSE
+    DocumentUsageFilterType.INCOME -> DocumentUsageType.INCOME
+    DocumentUsageFilterType.INVOICE -> DocumentUsageType.INVOICE
+    DocumentUsageFilterType.INCOME_TAX_PAYMENT -> DocumentUsageType.INCOME_TAX_PAYMENT
+    DocumentUsageFilterType.STANDALONE_DOCUMENT -> DocumentUsageType.STANDALONE_DOCUMENT
+    DocumentUsageFilterType.UNUSED -> null
+}

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/documents/DocumentsGqlApi.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/documents/DocumentsGqlApi.kt
@@ -4,10 +4,13 @@ import io.orangebuffalo.simpleaccounting.business.documents.DocumentsRepository
 import io.orangebuffalo.simpleaccounting.infra.graphql.connections.ConnectionGqlDto
 import io.orangebuffalo.simpleaccounting.infra.graphql.connections.GraphqlPaginationService
 import io.orangebuffalo.simpleaccounting.services.persistence.model.Tables
-import org.jooq.Condition
+import org.jooq.Table
 import org.jooq.impl.DSL
-import org.jooq.impl.DSL.exists
-import org.jooq.impl.DSL.selectOne
+import org.jooq.impl.DSL.count
+import org.jooq.impl.DSL.field
+import org.jooq.impl.DSL.inline
+import org.jooq.impl.DSL.name
+import org.jooq.impl.DSL.select
 import org.springframework.stereotype.Component
 
 @Component
@@ -34,108 +37,144 @@ class DocumentsGqlApi(
         freeSearchText: String?,
         storageIdsIn: List<String>?,
         usageTypeIn: List<DocumentUsageFilterType>?,
-    ): ConnectionGqlDto<DocumentGqlDto> = paginationService.forTable(document)
-        .addPredicate(document.workspaceId.eq(workspaceId))
-        .also {
-            if (freeSearchText != null) {
-                it.addPredicate(
-                    DSL.or(
-                        document.name.containsIgnoreCase(freeSearchText),
-                        usageExists(DocumentUsageType.EXPENSE, expense.title.containsIgnoreCase(freeSearchText)),
-                        usageExists(DocumentUsageType.INCOME, income.title.containsIgnoreCase(freeSearchText)),
-                        usageExists(DocumentUsageType.INVOICE, invoice.title.containsIgnoreCase(freeSearchText)),
-                        usageExists(
-                            DocumentUsageType.INCOME_TAX_PAYMENT,
-                            incomeTaxPayment.title.containsIgnoreCase(freeSearchText),
-                        ),
-                        usageExists(
-                            DocumentUsageType.STANDALONE_DOCUMENT,
-                            standaloneDocument.title.containsIgnoreCase(freeSearchText),
-                        ),
+    ): ConnectionGqlDto<DocumentGqlDto> {
+        val usageSummary = DocumentUsageSummary(freeSearchText)
+
+        return paginationService.forTable(document)
+            .onQuery { query ->
+                query.leftJoin(usageSummary.table).on(usageSummary.documentId.eq(document.id))
+            }
+            .addPredicate(document.workspaceId.eq(workspaceId))
+            .also {
+                if (freeSearchText != null) {
+                    it.addPredicate(
+                        DSL.or(
+                            document.name.containsIgnoreCase(freeSearchText),
+                            usageSummary.matchingTitleUsages.greaterThan(0),
+                        )
                     )
-                )
+                }
+                if (!storageIdsIn.isNullOrEmpty()) {
+                    it.addPredicate(document.storageId.`in`(storageIdsIn))
+                }
+                if (!usageTypeIn.isNullOrEmpty()) {
+                    it.addPredicate(DSL.or(usageTypeIn.map { usageSummary.matches(it) }))
+                }
             }
-            if (!storageIdsIn.isNullOrEmpty()) {
-                it.addPredicate(document.storageId.`in`(storageIdsIn))
-            }
-            if (!usageTypeIn.isNullOrEmpty()) {
-                it.addPredicate(DSL.or(usageTypeIn.map { usageFilterMatches(it) }))
-            }
+            .page(
+                first = first,
+                after = after,
+                mapQueryRecord = { record ->
+                    DocumentGqlDto(
+                        id = record[document.id]!!,
+                        version = record[document.version]!!,
+                        name = record[document.name]!!,
+                        timeUploaded = record[document.timeUploaded]!!,
+                        sizeInBytes = record[document.sizeInBytes],
+                        storageId = record[document.storageId]!!,
+                        mimeType = record[document.mimeType]!!,
+                        usedBy = emptyList(),
+                    )
+                },
+                postProcess = { records ->
+                    val usagesByDocId = documentsRepository.findUsagesByDocumentIds(records.map { it.id })
+                    records.map { item -> item.copy(usedBy = usagesByDocId[item.id] ?: emptyList()) }
+                },
+            )
+    }
+
+    private inner class DocumentUsageSummary(freeSearchText: String?) {
+        private val tableName = name("document_usage_summary")
+        private val documentUsagesTableName = name("document_usages")
+
+        val documentId = field(tableName.append("document_id"), String::class.java)
+        private val expenseUsages = field(tableName.append("expense_usages"), Int::class.java)
+        private val incomeUsages = field(tableName.append("income_usages"), Int::class.java)
+        private val invoiceUsages = field(tableName.append("invoice_usages"), Int::class.java)
+        private val incomeTaxPaymentUsages = field(tableName.append("income_tax_payment_usages"), Int::class.java)
+        private val standaloneDocumentUsages = field(tableName.append("standalone_document_usages"), Int::class.java)
+        val matchingTitleUsages = field(tableName.append("matching_title_usages"), Int::class.java)
+
+        private val usageDocumentId = field(documentUsagesTableName.append("document_id"), String::class.java)
+        private val usageType = field(documentUsagesTableName.append("usage_type"), String::class.java)
+        private val usageTitle = field(documentUsagesTableName.append("usage_title"), String::class.java)
+
+        val table: Table<*> = buildTable(freeSearchText)
+
+        fun matches(type: DocumentUsageFilterType) = when (type) {
+            DocumentUsageFilterType.EXPENSE -> expenseUsages.greaterThan(0)
+            DocumentUsageFilterType.INCOME -> incomeUsages.greaterThan(0)
+            DocumentUsageFilterType.INVOICE -> invoiceUsages.greaterThan(0)
+            DocumentUsageFilterType.INCOME_TAX_PAYMENT -> incomeTaxPaymentUsages.greaterThan(0)
+            DocumentUsageFilterType.STANDALONE_DOCUMENT -> standaloneDocumentUsages.greaterThan(0)
+            DocumentUsageFilterType.UNUSED -> documentId.isNull
         }
-        .page(
-            first = first,
-            after = after,
-            mapQueryRecord = { record ->
-                DocumentGqlDto(
-                    id = record[document.id]!!,
-                    version = record[document.version]!!,
-                    name = record[document.name]!!,
-                    timeUploaded = record[document.timeUploaded]!!,
-                    sizeInBytes = record[document.sizeInBytes],
-                    storageId = record[document.storageId]!!,
-                    mimeType = record[document.mimeType]!!,
-                    usedBy = emptyList(),
-                )
-            },
-            postProcess = { records ->
-                val usagesByDocId = documentsRepository.findUsagesByDocumentIds(records.map { it.id })
-                records.map { item -> item.copy(usedBy = usagesByDocId[item.id] ?: emptyList()) }
-            },
+
+        private fun buildTable(freeSearchText: String?): Table<*> {
+            val documentUsages = buildDocumentUsagesTable()
+            val matchingTitleUsagesField = if (freeSearchText == null) {
+                inline(0).`as`(matchingTitleUsages)
+            } else {
+                count().filterWhere(usageTitle.containsIgnoreCase(freeSearchText)).`as`(matchingTitleUsages)
+            }
+
+            return select(
+                usageDocumentId.`as`(documentId),
+                count().filterWhere(usageType.eq(DocumentUsageType.EXPENSE.name)).`as`(expenseUsages),
+                count().filterWhere(usageType.eq(DocumentUsageType.INCOME.name)).`as`(incomeUsages),
+                count().filterWhere(usageType.eq(DocumentUsageType.INVOICE.name)).`as`(invoiceUsages),
+                count().filterWhere(usageType.eq(DocumentUsageType.INCOME_TAX_PAYMENT.name)).`as`(incomeTaxPaymentUsages),
+                count().filterWhere(usageType.eq(DocumentUsageType.STANDALONE_DOCUMENT.name))
+                    .`as`(standaloneDocumentUsages),
+                matchingTitleUsagesField,
+            )
+                .from(documentUsages)
+                .groupBy(usageDocumentId)
+                .asTable(tableName.last())
+        }
+
+        private fun buildDocumentUsagesTable(): Table<*> = select(
+            expenseAttachments.documentId.`as`(usageDocumentId),
+            inline(DocumentUsageType.EXPENSE.name).`as`(usageType),
+            expense.title.`as`(usageTitle),
         )
-
-    private fun usageFilterMatches(type: DocumentUsageFilterType): Condition =
-        type.toDocumentUsageType()?.let { usageExists(it) } ?: noUsagesExist()
-
-    private fun noUsagesExist(): Condition = DSL.not(DSL.or(DocumentUsageType.entries.map { usageExists(it) }))
-
-    private fun usageExists(type: DocumentUsageType, usageTitleCondition: Condition? = null): Condition = when (type) {
-        DocumentUsageType.EXPENSE -> exists(
-            selectOne()
-                .from(expenseAttachments)
-                .join(expense).on(expense.id.eq(expenseAttachments.expenseId))
-                .where(
-                    expenseAttachments.documentId.eq(document.id),
-                    usageTitleCondition ?: DSL.trueCondition(),
+            .from(expenseAttachments)
+            .join(expense).on(expense.id.eq(expenseAttachments.expenseId))
+            .unionAll(
+                select(
+                    incomeAttachments.documentId.`as`(usageDocumentId),
+                    inline(DocumentUsageType.INCOME.name).`as`(usageType),
+                    income.title.`as`(usageTitle),
                 )
-        )
-
-        DocumentUsageType.INCOME -> exists(
-            selectOne()
-                .from(incomeAttachments)
-                .join(income).on(income.id.eq(incomeAttachments.incomeId))
-                .where(
-                    incomeAttachments.documentId.eq(document.id),
-                    usageTitleCondition ?: DSL.trueCondition(),
+                    .from(incomeAttachments)
+                    .join(income).on(income.id.eq(incomeAttachments.incomeId))
+            )
+            .unionAll(
+                select(
+                    invoiceAttachments.documentId.`as`(usageDocumentId),
+                    inline(DocumentUsageType.INVOICE.name).`as`(usageType),
+                    invoice.title.`as`(usageTitle),
                 )
-        )
-
-        DocumentUsageType.INVOICE -> exists(
-            selectOne()
-                .from(invoiceAttachments)
-                .join(invoice).on(invoice.id.eq(invoiceAttachments.invoiceId))
-                .where(
-                    invoiceAttachments.documentId.eq(document.id),
-                    usageTitleCondition ?: DSL.trueCondition(),
+                    .from(invoiceAttachments)
+                    .join(invoice).on(invoice.id.eq(invoiceAttachments.invoiceId))
+            )
+            .unionAll(
+                select(
+                    incomeTaxPaymentAttachments.documentId.`as`(usageDocumentId),
+                    inline(DocumentUsageType.INCOME_TAX_PAYMENT.name).`as`(usageType),
+                    incomeTaxPayment.title.`as`(usageTitle),
                 )
-        )
-
-        DocumentUsageType.INCOME_TAX_PAYMENT -> exists(
-            selectOne()
-                .from(incomeTaxPaymentAttachments)
-                .join(incomeTaxPayment).on(incomeTaxPayment.id.eq(incomeTaxPaymentAttachments.incomeTaxPaymentId))
-                .where(
-                    incomeTaxPaymentAttachments.documentId.eq(document.id),
-                    usageTitleCondition ?: DSL.trueCondition(),
+                    .from(incomeTaxPaymentAttachments)
+                    .join(incomeTaxPayment).on(incomeTaxPayment.id.eq(incomeTaxPaymentAttachments.incomeTaxPaymentId))
+            )
+            .unionAll(
+                select(
+                    standaloneDocument.documentId.`as`(usageDocumentId),
+                    inline(DocumentUsageType.STANDALONE_DOCUMENT.name).`as`(usageType),
+                    standaloneDocument.title.`as`(usageTitle),
                 )
-        )
-
-        DocumentUsageType.STANDALONE_DOCUMENT -> exists(
-            selectOne()
-                .from(standaloneDocument)
-                .where(
-                    standaloneDocument.documentId.eq(document.id),
-                    usageTitleCondition ?: DSL.trueCondition(),
-                )
-        )
+                    .from(standaloneDocument)
+            )
+            .asTable(documentUsagesTableName.last())
     }
 }

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/documents/DocumentsGqlApi.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/documents/DocumentsGqlApi.kt
@@ -1,0 +1,141 @@
+package io.orangebuffalo.simpleaccounting.business.api.documents
+
+import io.orangebuffalo.simpleaccounting.business.documents.DocumentsRepository
+import io.orangebuffalo.simpleaccounting.infra.graphql.connections.ConnectionGqlDto
+import io.orangebuffalo.simpleaccounting.infra.graphql.connections.GraphqlPaginationService
+import io.orangebuffalo.simpleaccounting.services.persistence.model.Tables
+import org.jooq.Condition
+import org.jooq.impl.DSL
+import org.jooq.impl.DSL.exists
+import org.jooq.impl.DSL.selectOne
+import org.springframework.stereotype.Component
+
+@Component
+class DocumentsGqlApi(
+    private val paginationService: GraphqlPaginationService,
+    private val documentsRepository: DocumentsRepository,
+) {
+
+    private val document = Tables.DOCUMENT
+    private val expenseAttachments = Tables.EXPENSE_ATTACHMENTS
+    private val incomeAttachments = Tables.INCOME_ATTACHMENTS
+    private val invoiceAttachments = Tables.INVOICE_ATTACHMENTS
+    private val incomeTaxPaymentAttachments = Tables.INCOME_TAX_PAYMENT_ATTACHMENTS
+    private val standaloneDocument = Tables.STANDALONE_DOCUMENT
+    private val expense = Tables.EXPENSE
+    private val income = Tables.INCOME
+    private val invoice = Tables.INVOICE
+    private val incomeTaxPayment = Tables.INCOME_TAX_PAYMENT
+
+    suspend fun loadDocuments(
+        workspaceId: String,
+        first: Int,
+        after: String?,
+        freeSearchText: String?,
+        storageIdsIn: List<String>?,
+        usageTypeIn: List<DocumentUsageFilterType>?,
+    ): ConnectionGqlDto<DocumentGqlDto> = paginationService.forTable(document)
+        .addPredicate(document.workspaceId.eq(workspaceId))
+        .also {
+            if (freeSearchText != null) {
+                it.addPredicate(
+                    DSL.or(
+                        document.name.containsIgnoreCase(freeSearchText),
+                        usageExists(DocumentUsageType.EXPENSE, expense.title.containsIgnoreCase(freeSearchText)),
+                        usageExists(DocumentUsageType.INCOME, income.title.containsIgnoreCase(freeSearchText)),
+                        usageExists(DocumentUsageType.INVOICE, invoice.title.containsIgnoreCase(freeSearchText)),
+                        usageExists(
+                            DocumentUsageType.INCOME_TAX_PAYMENT,
+                            incomeTaxPayment.title.containsIgnoreCase(freeSearchText),
+                        ),
+                        usageExists(
+                            DocumentUsageType.STANDALONE_DOCUMENT,
+                            standaloneDocument.title.containsIgnoreCase(freeSearchText),
+                        ),
+                    )
+                )
+            }
+            if (!storageIdsIn.isNullOrEmpty()) {
+                it.addPredicate(document.storageId.`in`(storageIdsIn))
+            }
+            if (!usageTypeIn.isNullOrEmpty()) {
+                it.addPredicate(DSL.or(usageTypeIn.map { usageFilterMatches(it) }))
+            }
+        }
+        .page(
+            first = first,
+            after = after,
+            mapQueryRecord = { record ->
+                DocumentGqlDto(
+                    id = record[document.id]!!,
+                    version = record[document.version]!!,
+                    name = record[document.name]!!,
+                    timeUploaded = record[document.timeUploaded]!!,
+                    sizeInBytes = record[document.sizeInBytes],
+                    storageId = record[document.storageId]!!,
+                    mimeType = record[document.mimeType]!!,
+                    usedBy = emptyList(),
+                )
+            },
+            postProcess = { records ->
+                val usagesByDocId = documentsRepository.findUsagesByDocumentIds(records.map { it.id })
+                records.map { item -> item.copy(usedBy = usagesByDocId[item.id] ?: emptyList()) }
+            },
+        )
+
+    private fun usageFilterMatches(type: DocumentUsageFilterType): Condition =
+        type.toDocumentUsageType()?.let { usageExists(it) } ?: noUsagesExist()
+
+    private fun noUsagesExist(): Condition = DSL.not(DSL.or(DocumentUsageType.entries.map { usageExists(it) }))
+
+    private fun usageExists(type: DocumentUsageType, usageTitleCondition: Condition? = null): Condition = when (type) {
+        DocumentUsageType.EXPENSE -> exists(
+            selectOne()
+                .from(expenseAttachments)
+                .join(expense).on(expense.id.eq(expenseAttachments.expenseId))
+                .where(
+                    expenseAttachments.documentId.eq(document.id),
+                    usageTitleCondition ?: DSL.trueCondition(),
+                )
+        )
+
+        DocumentUsageType.INCOME -> exists(
+            selectOne()
+                .from(incomeAttachments)
+                .join(income).on(income.id.eq(incomeAttachments.incomeId))
+                .where(
+                    incomeAttachments.documentId.eq(document.id),
+                    usageTitleCondition ?: DSL.trueCondition(),
+                )
+        )
+
+        DocumentUsageType.INVOICE -> exists(
+            selectOne()
+                .from(invoiceAttachments)
+                .join(invoice).on(invoice.id.eq(invoiceAttachments.invoiceId))
+                .where(
+                    invoiceAttachments.documentId.eq(document.id),
+                    usageTitleCondition ?: DSL.trueCondition(),
+                )
+        )
+
+        DocumentUsageType.INCOME_TAX_PAYMENT -> exists(
+            selectOne()
+                .from(incomeTaxPaymentAttachments)
+                .join(incomeTaxPayment).on(incomeTaxPayment.id.eq(incomeTaxPaymentAttachments.incomeTaxPaymentId))
+                .where(
+                    incomeTaxPaymentAttachments.documentId.eq(document.id),
+                    usageTitleCondition ?: DSL.trueCondition(),
+                )
+        )
+
+        DocumentUsageType.STANDALONE_DOCUMENT -> exists(
+            selectOne()
+                .from(standaloneDocument)
+                .where(
+                    standaloneDocument.documentId.eq(document.id),
+                    usageTitleCondition ?: DSL.trueCondition(),
+                )
+        )
+    }
+}

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/workspaces/WorkspaceGqlDto.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/business/api/workspaces/WorkspaceGqlDto.kt
@@ -10,6 +10,8 @@ import io.orangebuffalo.simpleaccounting.business.api.categories.loadCategoryByW
 import io.orangebuffalo.simpleaccounting.business.api.customers.CustomerGqlDto
 import io.orangebuffalo.simpleaccounting.business.api.customers.loadCustomerByWorkspaceAndId
 import io.orangebuffalo.simpleaccounting.business.api.documents.DocumentGqlDto
+import io.orangebuffalo.simpleaccounting.business.api.documents.DocumentUsageFilterType
+import io.orangebuffalo.simpleaccounting.business.api.documents.DocumentsGqlApi
 import io.orangebuffalo.simpleaccounting.business.api.expenses.ExpenseGqlDto
 import io.orangebuffalo.simpleaccounting.business.api.expenses.ExpensesGqlApi
 import io.orangebuffalo.simpleaccounting.business.api.expenses.loadExpenseByWorkspaceAndId
@@ -25,7 +27,6 @@ import io.orangebuffalo.simpleaccounting.business.api.generaltaxes.GeneralTaxGql
 import io.orangebuffalo.simpleaccounting.business.api.generaltaxes.loadGeneralTaxByWorkspaceAndId
 import io.orangebuffalo.simpleaccounting.business.api.incometaxpayments.IncomeTaxPaymentGqlDto
 import io.orangebuffalo.simpleaccounting.business.api.incometaxpayments.loadIncomeTaxPaymentByWorkspaceAndId
-import io.orangebuffalo.simpleaccounting.business.documents.DocumentsRepository
 import io.orangebuffalo.simpleaccounting.business.api.directives.RequiredAuth
 import io.orangebuffalo.simpleaccounting.infra.graphql.connections.ConnectionGqlDto
 import io.orangebuffalo.simpleaccounting.infra.graphql.connections.GraphqlPaginationConstants
@@ -187,32 +188,22 @@ data class WorkspaceGqlDto(
         @Max(GraphqlPaginationConstants.PAGE_SIZE_MAX)
         first: Int,
         @GraphQLDescription("Cursor after which to return items.") after: String? = null,
+        @GraphQLDescription("Optional free text search to filter documents by file name or usage title.")
+        freeSearchText: String? = null,
+        @GraphQLDescription("Optional filter to include only documents stored in any of the specified storages.")
+        storageIdsIn: List<String>? = null,
+        @GraphQLDescription("Optional filter to include only documents matching any of the specified usage states.")
+        usageTypeIn: List<DocumentUsageFilterType>? = null,
         env: DataFetchingEnvironment,
     ): ConnectionGqlDto<DocumentGqlDto> {
-        val document = Tables.DOCUMENT
-        val paginationService = env.graphQlContext.getBean<GraphqlPaginationService>()
-        val documentsRepository = env.graphQlContext.getBean<DocumentsRepository>()
-        return paginationService.forTable(document)
-            .addPredicate(document.workspaceId.eq(id))
-            .page(
+        return env.graphQlContext.getBean<DocumentsGqlApi>()
+            .loadDocuments(
+                workspaceId = id,
                 first = first,
                 after = after,
-                mapQueryRecord = { record ->
-                    DocumentGqlDto(
-                        id = record[document.id]!!,
-                        version = record[document.version]!!,
-                        name = record[document.name]!!,
-                        timeUploaded = record[document.timeUploaded]!!,
-                        sizeInBytes = record[document.sizeInBytes],
-                        storageId = record[document.storageId]!!,
-                        mimeType = record[document.mimeType]!!,
-                        usedBy = emptyList(),
-                    )
-                },
-                postProcess = { records ->
-                    val usagesByDocId = documentsRepository.findUsagesByDocumentIds(records.map { it.id })
-                    records.map { item -> item.copy(usedBy = usagesByDocId[item.id] ?: emptyList()) }
-                },
+                freeSearchText = freeSearchText,
+                storageIdsIn = storageIdsIn,
+                usageTypeIn = usageTypeIn,
             )
     }
 

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/documents/DocumentsQueryTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/documents/DocumentsQueryTest.kt
@@ -6,6 +6,7 @@ import io.orangebuffalo.simpleaccounting.business.workspaces.Workspace
 import io.orangebuffalo.simpleaccounting.infra.graphql.connections.encodeCursor
 import io.orangebuffalo.simpleaccounting.tests.infra.api.ApiTestClient
 import io.orangebuffalo.simpleaccounting.tests.infra.api.graphql
+import io.orangebuffalo.simpleaccounting.tests.infra.api.graphqlRawQuery
 import io.orangebuffalo.simpleaccounting.tests.infra.database.EntitiesFactory
 import io.orangebuffalo.simpleaccounting.tests.infra.utils.MOCK_TIME
 import kotlinx.serialization.json.JsonElement
@@ -307,6 +308,243 @@ class DocumentsQueryTest(
     }
 
     @Nested
+    @DisplayName("Filtering")
+    inner class Filtering {
+
+        private fun EntitiesFactory.documentsForFiltering() = object {
+            val fry = fry()
+            val workspace = workspace(owner = fry, name = "Planet Express")
+        }.also {
+            document(
+                workspace = it.workspace,
+                name = "Slurm manifest.pdf",
+                storageId = "test-storage",
+                createdAt = MOCK_TIME.plusSeconds(100),
+            )
+            val robotOilReceipt = document(
+                workspace = it.workspace,
+                name = "Expense attachment.pdf",
+                storageId = "noop",
+                createdAt = MOCK_TIME.plusSeconds(200),
+            )
+            val moonCargoReceipt = document(
+                workspace = it.workspace,
+                name = "Income attachment.pdf",
+                storageId = "google-drive",
+                createdAt = MOCK_TIME.plusSeconds(300),
+            )
+            val marsInvoiceReceipt = document(
+                workspace = it.workspace,
+                name = "Invoice attachment.pdf",
+                storageId = "local-fs",
+                createdAt = MOCK_TIME.plusSeconds(400),
+            )
+            val bureaucracyTaxReceipt = document(
+                workspace = it.workspace,
+                name = "Tax attachment.pdf",
+                storageId = "noop",
+                createdAt = MOCK_TIME.plusSeconds(500),
+            )
+            val goodNewsArchive = document(
+                workspace = it.workspace,
+                name = "Standalone attachment.pdf",
+                storageId = "local-fs",
+                createdAt = MOCK_TIME.plusSeconds(600),
+            )
+            document(
+                workspace = it.workspace,
+                name = "Unused neutral file.pdf",
+                storageId = "archive",
+                createdAt = MOCK_TIME.plusSeconds(700),
+            )
+
+            expense(workspace = it.workspace, title = "Robot oil delivery", attachments = setOf(robotOilReceipt))
+            income(workspace = it.workspace, title = "Moon cargo payment", attachments = setOf(moonCargoReceipt))
+            invoice(title = "Mars invoice", attachments = setOf(marsInvoiceReceipt))
+            incomeTaxPayment(workspace = it.workspace, title = "Central Bureaucracy tax", attachments = setOf(bureaucracyTaxReceipt))
+            standaloneDocument(title = "Good news archive", document = goodNewsArchive)
+
+            val otherWorkspace = workspace(owner = zoidberg(), name = "Zoidberg's Clinic")
+            document(workspace = otherWorkspace, name = "Slurm manifest from another universe")
+        }
+
+        @Test
+        fun `should filter documents by free search text in file name`() {
+            val testData = preconditions { documentsForFiltering() }
+
+            client.documentsRawQuery(testData.workspace.id!!, "freeSearchText: \"slurm\"")
+                .from(testData.fry)
+                .executeAndVerifyResponse(documentsResponse("Slurm manifest.pdf", totalCount = 1))
+        }
+
+        @Test
+        fun `should filter documents by free search text in usage title for all usage types`() {
+            val testData = preconditions { documentsForFiltering() }
+
+            mapOf(
+                "robot" to "Expense attachment.pdf",
+                "cargo" to "Income attachment.pdf",
+                "mars" to "Invoice attachment.pdf",
+                "bureaucracy" to "Tax attachment.pdf",
+                "good news" to "Standalone attachment.pdf",
+            ).forEach { (searchText, expectedDocumentName) ->
+                client.documentsRawQuery(testData.workspace.id!!, "freeSearchText: \"$searchText\"")
+                    .from(testData.fry)
+                    .executeAndVerifyResponse(documentsResponse(expectedDocumentName, totalCount = 1))
+            }
+        }
+
+        @Test
+        fun `should filter documents by free search text case insensitively`() {
+            val testData = preconditions { documentsForFiltering() }
+
+            client.documentsRawQuery(testData.workspace.id!!, "freeSearchText: \"bUrEaUcRaCy\"")
+                .from(testData.fry)
+                .executeAndVerifyResponse(documentsResponse("Tax attachment.pdf", totalCount = 1))
+        }
+
+        @Test
+        fun `should filter documents by storage ids`() {
+            val testData = preconditions { documentsForFiltering() }
+
+            client.documentsRawQuery(testData.workspace.id!!, "storageIdsIn: [\"noop\", \"local-fs\"]")
+                .from(testData.fry)
+                .executeAndVerifyResponse(documentsResponse(
+                    "Standalone attachment.pdf",
+                    "Tax attachment.pdf",
+                    "Invoice attachment.pdf",
+                    "Expense attachment.pdf",
+                    totalCount = 4,
+                ))
+        }
+
+        @Test
+        fun `should not apply storage ids filter when empty list is provided`() {
+            val testData = preconditions { documentsForFiltering() }
+
+            client.documentsRawQuery(testData.workspace.id!!, "storageIdsIn: []")
+                .from(testData.fry)
+                .executeAndVerifyResponse(documentsResponse(
+                    "Unused neutral file.pdf",
+                    "Standalone attachment.pdf",
+                    "Tax attachment.pdf",
+                    "Invoice attachment.pdf",
+                    "Income attachment.pdf",
+                    "Expense attachment.pdf",
+                    "Slurm manifest.pdf",
+                    totalCount = 7,
+                ))
+        }
+
+        @Test
+        fun `should filter documents by each usage type`() {
+            val testData = preconditions { documentsForFiltering() }
+
+            mapOf(
+                "EXPENSE" to "Expense attachment.pdf",
+                "INCOME" to "Income attachment.pdf",
+                "INVOICE" to "Invoice attachment.pdf",
+                "INCOME_TAX_PAYMENT" to "Tax attachment.pdf",
+                "STANDALONE_DOCUMENT" to "Standalone attachment.pdf",
+            ).forEach { (usageType, expectedDocumentName) ->
+                client.documentsRawQuery(testData.workspace.id!!, "usageTypeIn: [$usageType]")
+                    .from(testData.fry)
+                    .executeAndVerifyResponse(documentsResponse(expectedDocumentName, totalCount = 1))
+            }
+        }
+
+        @Test
+        fun `should filter documents by unused usage type`() {
+            val testData = preconditions { documentsForFiltering() }
+
+            client.documentsRawQuery(testData.workspace.id!!, "usageTypeIn: [UNUSED]")
+                .from(testData.fry)
+                .executeAndVerifyResponse(documentsResponse(
+                    "Unused neutral file.pdf",
+                    "Slurm manifest.pdf",
+                    totalCount = 2,
+                ))
+        }
+
+        @Test
+        fun `should apply OR logic between usage types`() {
+            val testData = preconditions { documentsForFiltering() }
+
+            client.documentsRawQuery(
+                testData.workspace.id!!,
+                "usageTypeIn: [EXPENSE, INCOME, INVOICE, INCOME_TAX_PAYMENT, STANDALONE_DOCUMENT, UNUSED]",
+            )
+                .from(testData.fry)
+                .executeAndVerifyResponse(documentsResponse(
+                    "Unused neutral file.pdf",
+                    "Standalone attachment.pdf",
+                    "Tax attachment.pdf",
+                    "Invoice attachment.pdf",
+                    "Income attachment.pdf",
+                    "Expense attachment.pdf",
+                    "Slurm manifest.pdf",
+                    totalCount = 7,
+                ))
+        }
+
+        @Test
+        fun `should combine unused usage type with used usage types using OR logic`() {
+            val testData = preconditions { documentsForFiltering() }
+
+            client.documentsRawQuery(testData.workspace.id!!, "usageTypeIn: [UNUSED, EXPENSE]")
+                .from(testData.fry)
+                .executeAndVerifyResponse(documentsResponse(
+                    "Unused neutral file.pdf",
+                    "Expense attachment.pdf",
+                    "Slurm manifest.pdf",
+                    totalCount = 3,
+                ))
+        }
+
+        @Test
+        fun `should not apply usage type filter when empty list is provided`() {
+            val testData = preconditions { documentsForFiltering() }
+
+            client.documentsRawQuery(testData.workspace.id!!, "usageTypeIn: []")
+                .from(testData.fry)
+                .executeAndVerifyResponse(documentsResponse(
+                    "Unused neutral file.pdf",
+                    "Standalone attachment.pdf",
+                    "Tax attachment.pdf",
+                    "Invoice attachment.pdf",
+                    "Income attachment.pdf",
+                    "Expense attachment.pdf",
+                    "Slurm manifest.pdf",
+                    totalCount = 7,
+                ))
+        }
+
+        @Test
+        fun `should combine filters with AND logic`() {
+            val testData = preconditions { documentsForFiltering() }
+
+            client.documentsRawQuery(
+                testData.workspace.id!!,
+                "freeSearchText: \"mars\", storageIdsIn: [\"local-fs\"], usageTypeIn: [INVOICE]",
+            )
+                .from(testData.fry)
+                .executeAndVerifyResponse(documentsResponse("Invoice attachment.pdf", totalCount = 1))
+        }
+
+        @Test
+        fun `should return empty connection when combined filters do not match`() {
+            val testData = preconditions { documentsForFiltering() }
+
+            client.documentsRawQuery(
+                testData.workspace.id!!,
+                "freeSearchText: \"mars\", storageIdsIn: [\"noop\"], usageTypeIn: [INVOICE]",
+            )
+                .from(testData.fry)
+                .executeAndVerifyResponse(documentsResponse(totalCount = 0))
+        }
+    }
+
+    @Nested
     @DisplayName("Document Fields")
     inner class DocumentFields {
         @Test
@@ -595,6 +833,31 @@ private fun emptyDocumentsConnection(
     })
     put("totalCount", totalCount)
 }
+
+private fun ApiTestClient.documentsRawQuery(workspaceId: String, args: String) = graphqlRawQuery(
+    """
+        query {
+          workspace(id: "$workspaceId") {
+            documents(first: 10, $args) {
+              edges {
+                node { name }
+              }
+              totalCount
+            }
+          }
+        }
+    """.trimIndent()
+)
+
+private fun documentsResponse(vararg documentNames: String, totalCount: Int): Pair<String, JsonElement> =
+    "workspace" to buildJsonObject {
+        put("documents", buildJsonObject {
+            putJsonArray("edges") {
+                documentNames.forEach { documentEdge(name = it) }
+            }
+            put("totalCount", totalCount)
+        })
+    }
 
 private fun kotlinx.serialization.json.JsonArrayBuilder.documentEdge(name: String) {
     add(buildJsonObject {

--- a/app/src/test/resources/api-schema.graphqls
+++ b/app/src/test/resources/api-schema.graphqls
@@ -1315,7 +1315,13 @@ type Workspace {
     "Cursor after which to return items."
     after: String,
     "The maximum number of items to return."
-    first: Int!
+    first: Int!,
+    "Optional free text search to filter documents by file name or usage title."
+    freeSearchText: String,
+    "Optional filter to include only documents stored in any of the specified storages."
+    storageIdsIn: [String!],
+    "Optional filter to include only documents matching any of the specified usage states."
+    usageTypeIn: [DocumentUsageFilterType!]
   ): DocumentsConnection!
   "Returns an expense by its ID if it belongs to this workspace, or null if not found."
   expense(
@@ -1562,6 +1568,22 @@ enum CreateUserErrorCodes {
 enum DeleteDocumentErrorCodes {
   "The document is attached to another entity and cannot be deleted."
   DOCUMENT_IS_USED
+}
+
+"Usage type filter for documents."
+enum DocumentUsageFilterType {
+  "Document is used by an expense."
+  EXPENSE
+  "Document is used by an income."
+  INCOME
+  "Document is used by an income tax payment."
+  INCOME_TAX_PAYMENT
+  "Document is used by an invoice."
+  INVOICE
+  "Document is used by a standalone document."
+  STANDALONE_DOCUMENT
+  "Document is not used by any entity."
+  UNUSED
 }
 
 "Type of entity that uses a document."

--- a/frontend/src/services/api/gql/schema-types.ts
+++ b/frontend/src/services/api/gql/schema-types.ts
@@ -249,6 +249,22 @@ export type DocumentUsage = {
   type: DocumentUsageType;
 };
 
+/** Usage type filter for documents. */
+export enum DocumentUsageFilterType {
+  /** Document is used by an expense. */
+  Expense = 'EXPENSE',
+  /** Document is used by an income. */
+  Income = 'INCOME',
+  /** Document is used by an income tax payment. */
+  IncomeTaxPayment = 'INCOME_TAX_PAYMENT',
+  /** Document is used by an invoice. */
+  Invoice = 'INVOICE',
+  /** Document is used by a standalone document. */
+  StandaloneDocument = 'STANDALONE_DOCUMENT',
+  /** Document is not used by any entity. */
+  Unused = 'UNUSED'
+}
+
 /** Type of entity that uses a document. */
 export enum DocumentUsageType {
   /** Document is used by an expense. */
@@ -1473,6 +1489,9 @@ export type WorkspaceCustomersArgs = {
 export type WorkspaceDocumentsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   first: Scalars['Int']['input'];
+  freeSearchText?: InputMaybe<Scalars['String']['input']>;
+  storageIdsIn?: InputMaybe<Array<Scalars['String']['input']>>;
+  usageTypeIn?: InputMaybe<Array<DocumentUsageFilterType>>;
 };
 
 


### PR DESCRIPTION
## Problem statement

Documents pagination could only page by workspace and did not support filtering by document text, storage, usage type, or unused state.

## Solution summary

Added document pagination filters for free-text, storage IDs, and usage state including `UNUSED`. Introduced a dedicated filter enum separate from the document usage DTO enum, moved document query logic into a document API component, and backed usage filters with a reusable usage summary join.

## Notes

GraphQL schema and frontend schema types were regenerated for the new document filter arguments and enum.
