### PR TITLE
tests: Stabilize workspace update full stack test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,16 @@ For GraphQL changes, regenerate committed artifacts as needed before validation:
 - **Frontend tests**: Vitest for limited cases of complex logic 
 - **Full stack tests**: Playwright
 
+### Test Parallelization Model
+- Backend and full stack test parallelism is implemented with separate JVM forks, not concurrent JUnit execution inside the
+  same Spring `ApplicationContext` or H2 database.
+- Do not assume two tests are mutating the same database or sharing the same Spring context concurrently when diagnosing CI
+  failures. Each fork has its own process-local Spring context and in-memory database.
+- Avoid changing generic test authentication, context, database, or mocking infrastructure to fix a suspected same-context
+  test race unless there is concrete evidence that the failure occurs within one JVM fork.
+- If a full `:app:test` run reports many unrelated failures after a test infrastructure change, treat the infrastructure
+  change itself as the likely cause and revert or narrow it before investigating individual failed tests.
+
 ## General Coding Guidelines
 
 1. Be concise and clear in your responses. Avoid extra details unless specifically requested.

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/workspaces/EditWorkspaceFullStackTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/workspaces/EditWorkspaceFullStackTest.kt
@@ -52,7 +52,9 @@ class EditWorkspaceFullStackTest : SaFullStackTestBase() {
             saveButton.click()
         }
 
-        page.shouldBeWorkspacesOverviewPage()
+        page.shouldBeWorkspacesOverviewPage {
+            shouldHaveWorkspaces("Mom's Friendly Robot Company")
+        }
 
         aggregateTemplate.findSingle<Workspace>(testData.workspace.id!!)
             .shouldBeEntityWithFields(


### PR DESCRIPTION
## Problem statement

CI investigation exposed a flaky workspace update full-stack assertion and a need to document the test parallelization model clearly for future debugging.

## Solution summary

Wait for the updated workspace to appear on the overview page before checking database state, and document that backend/full-stack parallelism uses isolated JVM forks rather than concurrent tests in one Spring context.

## Notes

The documentation calls out that broad generic test infrastructure changes should be avoided unless there is concrete evidence of a same-context failure.
