### PR TITLE
fix: Aggregate GraphQL input validation errors

### DIFF
--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/graphql/SaDataFetcherExceptionHandler.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/graphql/SaDataFetcherExceptionHandler.kt
@@ -19,17 +19,15 @@ import mu.KotlinLogging
 import org.springframework.stereotype.Component
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
-import kotlin.reflect.KClass
-
 private val log = KotlinLogging.logger { }
-
-private val mappingsByAnnotationClass: Map<KClass<out Annotation>, ValidationDirectiveMapping> =
-    validationDirectiveMappings.associateBy { it.annotationClass }
 
 @Component
 class SaDataFetcherExceptionHandler(
     private val businessErrorRegistry: BusinessErrorRegistry,
+    validationDirectiveMappings: List<ValidationDirectiveMapping>,
 ) : DataFetcherExceptionHandler {
+    private val mappingsByAnnotationClass = validationDirectiveMappings.associateBy { it.annotationClass }
+
     override fun handleException(handlerParameters: DataFetcherExceptionHandlerParameters): CompletableFuture<DataFetcherExceptionHandlerResult> {
         return CompletableFuture.completedFuture(mapToResult(handlerParameters))
     }
@@ -40,7 +38,7 @@ class SaDataFetcherExceptionHandler(
         // Handle Bean Validation exceptions
         if (exception is ConstraintViolationException) {
             return DataFetcherExceptionHandlerResult.newResult()
-                .error(ValidationErrorGraphQLError(exception, handlerParameters))
+                .error(ValidationErrorGraphQLError(exception, handlerParameters, mappingsByAnnotationClass))
                 .build()
         }
 
@@ -153,6 +151,7 @@ private class BusinessErrorGraphQLError(
 private class ValidationErrorGraphQLError(
     private val exception: ConstraintViolationException,
     private val handlerParameters: DataFetcherExceptionHandlerParameters,
+    private val mappingsByAnnotationClass: Map<kotlin.reflect.KClass<out Annotation>, ValidationDirectiveMapping>,
 ) : GraphQLError {
     override fun getMessage(): String = "Validation failed"
 

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/graphql/SaGraphQLInputValidationInstrumentation.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/graphql/SaGraphQLInputValidationInstrumentation.kt
@@ -1,0 +1,192 @@
+package io.orangebuffalo.simpleaccounting.infra.graphql
+
+import graphql.GraphQLError
+import graphql.execution.instrumentation.InstrumentationContext
+import graphql.execution.instrumentation.InstrumentationState
+import graphql.execution.instrumentation.SimplePerformantInstrumentation
+import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters
+import graphql.language.BooleanValue
+import graphql.language.Field
+import graphql.language.FloatValue
+import graphql.language.IntValue
+import graphql.language.NullValue
+import graphql.language.OperationDefinition
+import graphql.language.SelectionSet
+import graphql.language.SourceLocation
+import graphql.language.StringValue
+import graphql.language.Value
+import graphql.language.VariableReference
+import graphql.schema.GraphQLArgument
+import graphql.schema.GraphQLFieldsContainer
+import graphql.schema.GraphQLNonNull
+import graphql.schema.GraphQLObjectType
+import graphql.validation.ValidationError
+import graphql.validation.ValidationErrorType
+import io.orangebuffalo.simpleaccounting.business.api.errors.ValidationErrorCode
+import io.orangebuffalo.simpleaccounting.business.api.errors.ValidationErrorDetails
+import org.springframework.stereotype.Component
+
+internal const val SA_VALIDATION_ERRORS_EXTENSION = "saValidationErrors"
+internal const val SA_VALIDATION_QUERY_PATH_EXTENSION = "saValidationQueryPath"
+
+/**
+ * Performs Simple Accounting input validation before graphql-java coerces variables.
+ *
+ * graphql-java aborts variable coercion on the first null supplied for a non-null value. By validating raw
+ * variables against the selected operation and schema during the validation phase, we can report all null fields
+ * in a single response and stop execution before the fail-fast coercion path runs.
+ */
+@Component
+class SaGraphQLInputValidationInstrumentation(
+    validationDirectiveMappings: List<ValidationDirectiveMapping>,
+) : SimplePerformantInstrumentation() {
+
+    private val validationDirectiveMappingsByName = validationDirectiveMappings.associateBy { it.directiveName }
+
+    override fun beginValidation(
+        parameters: InstrumentationValidationParameters,
+        state: InstrumentationState?,
+    ): InstrumentationContext<List<ValidationError>> = object : InstrumentationContext<List<ValidationError>> {
+        override fun onDispatched() = Unit
+
+        override fun onCompleted(result: List<ValidationError>, t: Throwable?) {
+            if (t != null) return
+
+            val operation = findOperation(parameters) ?: return
+            val rootType = when (operation.operation) {
+                OperationDefinition.Operation.MUTATION -> parameters.schema.mutationType
+                OperationDefinition.Operation.QUERY -> parameters.schema.queryType
+                OperationDefinition.Operation.SUBSCRIPTION -> parameters.schema.subscriptionType
+                else -> null
+            } ?: return
+
+            val validationErrors = validateSelectionSet(
+                selectionSet = operation.selectionSet,
+                parentType = rootType,
+                variables = parameters.variables,
+                variableLocations = operation.variableDefinitions.associate { it.name to it.sourceLocation },
+            )
+            if (validationErrors.isEmpty()) return
+
+            @Suppress("UNCHECKED_CAST")
+            (result as? MutableList<ValidationError>)?.add(buildValidationError(validationErrors))
+        }
+    }
+
+    private fun findOperation(parameters: InstrumentationValidationParameters): OperationDefinition? {
+        val operations = parameters.document.getDefinitionsOfType(OperationDefinition::class.java)
+        val operationName = parameters.operation
+        return if (operationName != null) {
+            operations.firstOrNull { it.name == operationName }
+        } else {
+            operations.singleOrNull()
+        }
+    }
+
+    private fun validateSelectionSet(
+        selectionSet: SelectionSet,
+        parentType: GraphQLObjectType,
+        variables: Map<String, Any>,
+        variableLocations: Map<String, SourceLocation>,
+    ): List<PreCoercionValidationErrorDetails> = selectionSet
+        .getSelectionsOfType(Field::class.java)
+        .flatMap { field -> validateField(field, parentType, variables, variableLocations) }
+
+    private fun validateField(
+        field: Field,
+        parentType: GraphQLFieldsContainer,
+        variables: Map<String, Any>,
+        variableLocations: Map<String, SourceLocation>,
+    ): List<PreCoercionValidationErrorDetails> {
+        val fieldDefinition = parentType.getFieldDefinition(field.name) ?: return emptyList()
+        val providedArguments = field.arguments.associateBy { it.name }
+
+        return fieldDefinition.arguments.flatMap { argumentDefinition ->
+            val argument = providedArguments[argumentDefinition.name]
+            val value = argument?.value
+            val sourceLocation = when (value) {
+                is VariableReference -> variableLocations[value.name] ?: value.sourceLocation
+                else -> field.sourceLocation
+            }
+            val queryPath = listOf(field.name)
+
+            val resolvedValue = resolveValue(value, variables)
+            val directiveErrors = validateAppliedDirectives(argumentDefinition, resolvedValue, sourceLocation, queryPath)
+            if (directiveErrors.isNotEmpty()) {
+                directiveErrors
+            } else if (argumentDefinition.isRequired() && resolvedValue == null) {
+                listOf(
+                    PreCoercionValidationErrorDetails(
+                        validationError = ValidationErrorDetails(
+                            path = argumentDefinition.name,
+                            error = ValidationErrorCode.MustNotBeNull,
+                            message = "must not be null",
+                        ),
+                        sourceLocation = sourceLocation,
+                        queryPath = queryPath,
+                    )
+                )
+            } else {
+                emptyList()
+            }
+        }
+    }
+
+    private fun resolveValue(value: Value<*>?, variables: Map<String, Any>): Any? = when (value) {
+        null -> null
+        is NullValue -> null
+        is VariableReference -> variables[value.name]
+        is StringValue -> value.value
+        is BooleanValue -> value.isValue
+        is IntValue -> value.value.toLong()
+        is FloatValue -> value.value
+        else -> null
+    }
+
+    private fun validateAppliedDirectives(
+        argumentDefinition: GraphQLArgument,
+        value: Any?,
+        sourceLocation: SourceLocation,
+        queryPath: List<String>,
+    ): List<PreCoercionValidationErrorDetails> = argumentDefinition.appliedDirectives.mapNotNull { directive ->
+        val mapping = validationDirectiveMappingsByName[directive.name] ?: return@mapNotNull null
+        val validationError = mapping.runtimeValidator(argumentDefinition.name, value, directive) ?: return@mapNotNull null
+
+        PreCoercionValidationErrorDetails(validationError, sourceLocation, queryPath)
+    }
+
+    private fun GraphQLArgument.isRequired(): Boolean = type is GraphQLNonNull && !hasSetDefaultValue()
+
+    private fun buildValidationError(validationErrors: List<PreCoercionValidationErrorDetails>): ValidationError =
+        ValidationError.newValidationError()
+            .validationErrorType(ValidationErrorType.NullValueForNonNullArgument)
+            .description("Validation failed")
+            .sourceLocation(validationErrors.first().sourceLocation)
+            .extensions(
+                mapOf(
+                    SA_VALIDATION_ERRORS_EXTENSION to validationErrors.map { it.validationError },
+                    SA_VALIDATION_QUERY_PATH_EXTENSION to validationErrors.first().queryPath,
+                )
+            )
+            .build()
+
+    private data class PreCoercionValidationErrorDetails(
+        val validationError: ValidationErrorDetails,
+        val sourceLocation: SourceLocation,
+        val queryPath: List<String>,
+    )
+}
+
+internal fun GraphQLError.getSaValidationErrors(): List<ValidationErrorDetails> {
+    val rawValidationErrors = extensions?.get(SA_VALIDATION_ERRORS_EXTENSION) ?: return emptyList()
+
+    @Suppress("UNCHECKED_CAST")
+    return rawValidationErrors as? List<ValidationErrorDetails> ?: emptyList()
+}
+
+internal fun GraphQLError.getSaValidationQueryPath(): List<String> {
+    val rawQueryPath = extensions?.get(SA_VALIDATION_QUERY_PATH_EXTENSION) ?: return emptyList()
+
+    @Suppress("UNCHECKED_CAST")
+    return rawQueryPath as? List<String> ?: emptyList()
+}

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/graphql/SaGraphQLNullFieldValidationInstrumentation.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/graphql/SaGraphQLNullFieldValidationInstrumentation.kt
@@ -60,15 +60,23 @@ class SaGraphQLNullFieldValidationInstrumentation : Instrumentation {
         state: InstrumentationState?,
     ): CompletableFuture<ExecutionResult> {
         val nullFieldErrors = collectNullFieldErrors(executionResult)
+        val preCoercionValidationErrors = collectPreCoercionValidationErrors(executionResult)
 
-        if (nullFieldErrors.isEmpty()) {
+        if (nullFieldErrors.isEmpty() && preCoercionValidationErrors.isEmpty()) {
             return CompletableFuture.completedFuture(executionResult)
         }
 
-        val handledErrors = nullFieldErrors.map { it.originalError }.toSet()
+        val preCoercionValidationPaths = preCoercionValidationErrors
+            .flatMap { error -> error.validationDetails.map { it.path } }
+            .toSet()
+        val nullFieldErrorsToTransform = nullFieldErrors
+            .filterNot { it.fieldName in preCoercionValidationPaths }
+
+        val handledErrors = (nullFieldErrors.map { it.originalError } + preCoercionValidationErrors.map { it.originalError })
+            .toSet()
         val otherErrors = executionResult.errors.filter { it !in handledErrors }
 
-        val transformedErrors = nullFieldErrors
+        val transformedNullFieldErrors = nullFieldErrorsToTransform
             .groupBy { it.queryPath }
             .map { (queryPath, errors) ->
                 val validationDetails = errors
@@ -87,9 +95,17 @@ class SaGraphQLNullFieldValidationInstrumentation : Instrumentation {
                 )
             }
 
+        val transformedPreCoercionValidationErrors = preCoercionValidationErrors.map { error ->
+            NullFieldValidationFailureGraphQLError(
+                queryPath = error.queryPath,
+                validationDetails = error.validationDetails,
+                sourceLocation = error.originalError.locations?.firstOrNull(),
+            )
+        }
+
         return CompletableFuture.completedFuture(
             executionResult.transform { builder ->
-                builder.errors(otherErrors + transformedErrors)
+                builder.errors(otherErrors + transformedNullFieldErrors + transformedPreCoercionValidationErrors)
             }
         )
     }
@@ -112,10 +128,27 @@ class SaGraphQLNullFieldValidationInstrumentation : Instrumentation {
                 )
             }
 
+    private fun collectPreCoercionValidationErrors(executionResult: ExecutionResult): List<PreCoercionValidationError> =
+        executionResult.errors
+            .mapNotNull { error ->
+                val validationDetails = error.getSaValidationErrors()
+                if (validationDetails.isEmpty()) {
+                    null
+                } else {
+                    PreCoercionValidationError(error, validationDetails)
+                }
+            }
+
     private data class NullFieldError(
         val originalError: GraphQLError,
         val fieldName: String,
         val queryPath: List<String>,
+    )
+
+    private data class PreCoercionValidationError(
+        val originalError: GraphQLError,
+        val validationDetails: List<ValidationErrorDetails>,
+        val queryPath: List<String> = originalError.getSaValidationQueryPath(),
     )
 }
 

--- a/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/graphql/ValidationSchemaTransformer.kt
+++ b/app/src/main/kotlin/io/orangebuffalo/simpleaccounting/infra/graphql/ValidationSchemaTransformer.kt
@@ -7,6 +7,7 @@ import graphql.introspection.Introspection
 import graphql.language.IntValue
 import graphql.schema.*
 import io.orangebuffalo.simpleaccounting.business.api.errors.ValidationErrorCode
+import io.orangebuffalo.simpleaccounting.business.api.errors.ValidationErrorDetails
 import io.orangebuffalo.simpleaccounting.business.api.errors.ValidationErrorParam
 import jakarta.validation.ConstraintViolation
 import jakarta.validation.constraints.Max
@@ -22,14 +23,15 @@ import kotlin.reflect.full.memberFunctions
  * Registry entry that defines how a Jakarta validation annotation maps to a GraphQL directive
  * and how constraint violations are transformed into error responses.
  */
-data class ValidationDirectiveMapping(
+open class ValidationDirectiveMapping(
     val annotationClass: KClass<out Annotation>,
     val directiveName: String,
     val directiveDescription: String,
     val directiveArgumentsBuilder: (GraphQLDirective.Builder) -> Unit = {},
     val appliedDirectiveArgumentsBuilder: (GraphQLAppliedDirective.Builder, Annotation) -> Unit = { _, _ -> },
     val errorCode: ValidationErrorCode,
-    val paramsExtractor: ((ConstraintViolation<*>) -> List<ValidationErrorParam>)? = null
+    val paramsExtractor: ((ConstraintViolation<*>) -> List<ValidationErrorParam>)? = null,
+    val runtimeValidator: (path: String, value: Any?, directive: GraphQLAppliedDirective) -> ValidationErrorDetails? = { _, _, _ -> null },
 ) {
     fun buildAppliedDirective(annotation: Annotation): GraphQLAppliedDirective =
         GraphQLAppliedDirective.newDirective()
@@ -38,18 +40,28 @@ data class ValidationDirectiveMapping(
             .build()
 }
 
-/**
- * Single registry of all supported validation annotations with their directive mappings.
- * This provides cohesive definitions that are easy to track and understand.
- */
-val validationDirectiveMappings: List<ValidationDirectiveMapping> = listOf(
-    ValidationDirectiveMapping(
+@Component
+class NotBlankValidationDirective : ValidationDirectiveMapping(
         annotationClass = NotBlank::class,
         directiveName = "notBlank",
         directiveDescription = "Validates that the string is not null, empty, or blank",
-        errorCode = ValidationErrorCode.MustNotBeBlank
-    ),
-    ValidationDirectiveMapping(
+        errorCode = ValidationErrorCode.MustNotBeBlank,
+        runtimeValidator = { path, value, _ ->
+            val stringValue = value as? String
+            if (stringValue == null || stringValue.isBlank()) {
+                ValidationErrorDetails(
+                    path = path,
+                    error = ValidationErrorCode.MustNotBeBlank,
+                    message = "must not be blank",
+                )
+            } else {
+                null
+            }
+        }
+)
+
+@Component
+class SizeValidationDirective : ValidationDirectiveMapping(
         annotationClass = Size::class,
         directiveName = "size",
         directiveDescription = "Validates the size of a string",
@@ -91,9 +103,29 @@ val validationDirectiveMappings: List<ValidationDirectiveMapping> = listOf(
                 ValidationErrorParam("min", attributes["min"]?.toString() ?: "0"),
                 ValidationErrorParam("max", attributes["max"]?.toString() ?: "2147483647")
             )
+        },
+        runtimeValidator = { path, value, directive ->
+            val stringValue = value as? String
+            val min = directive.intArgument("min") ?: 0
+            val max = directive.intArgument("max") ?: Int.MAX_VALUE
+            if (stringValue != null && (stringValue.length < min || stringValue.length > max)) {
+                ValidationErrorDetails(
+                    path = path,
+                    error = ValidationErrorCode.SizeConstraintViolated,
+                    message = "size must be between $min and $max",
+                    params = listOf(
+                        ValidationErrorParam("min", min.toString()),
+                        ValidationErrorParam("max", max.toString()),
+                    )
+                )
+            } else {
+                null
+            }
         }
-    ),
-    ValidationDirectiveMapping(
+)
+
+@Component
+class MaxValidationDirective : ValidationDirectiveMapping(
         annotationClass = Max::class,
         directiveName = "max",
         directiveDescription = "Validates that the value is at most the specified maximum",
@@ -122,9 +154,25 @@ val validationDirectiveMappings: List<ValidationDirectiveMapping> = listOf(
             listOf(
                 ValidationErrorParam("value", attributes["value"]?.toString() ?: "")
             )
+        },
+        runtimeValidator = { path, value, directive ->
+            val numberValue = (value as? Number)?.toLong()
+            val max = directive.intArgument("value")
+            if (numberValue != null && max != null && numberValue > max) {
+                ValidationErrorDetails(
+                    path = path,
+                    error = ValidationErrorCode.MaxConstraintViolated,
+                    message = "must be less than or equal to $max",
+                    params = listOf(ValidationErrorParam("value", max.toString())),
+                )
+            } else {
+                null
+            }
         }
-    ),
-    ValidationDirectiveMapping(
+)
+
+@Component
+class MinValidationDirective : ValidationDirectiveMapping(
         annotationClass = Min::class,
         directiveName = "min",
         directiveDescription = "Validates that the value is at least the specified minimum",
@@ -153,19 +201,37 @@ val validationDirectiveMappings: List<ValidationDirectiveMapping> = listOf(
             listOf(
                 ValidationErrorParam("value", attributes["value"]?.toString() ?: "")
             )
+        },
+        runtimeValidator = { path, value, directive ->
+            val numberValue = (value as? Number)?.toLong()
+            val min = directive.intArgument("value")
+            if (numberValue != null && min != null && numberValue < min) {
+                ValidationErrorDetails(
+                    path = path,
+                    error = ValidationErrorCode.MinConstraintViolated,
+                    message = "must be greater than or equal to $min",
+                    params = listOf(ValidationErrorParam("value", min.toString())),
+                )
+            } else {
+                null
+            }
         }
-    )
 )
 
-private val mappingsByAnnotationClass: Map<KClass<out Annotation>, ValidationDirectiveMapping> =
-    validationDirectiveMappings.associateBy { it.annotationClass }
+internal fun GraphQLAppliedDirective.intArgument(name: String): Int? = getArgument(name)?.getValue<Int>()
 
 /**
  * Transforms the GraphQL schema by adding validation directives based on Jakarta validation annotations.
  * This makes validation constraints visible in the schema for API documentation purposes.
  */
 @Component
-class ValidationSchemaTransformer {
+class ValidationSchemaTransformer(
+    validationDirectiveMappings: List<ValidationDirectiveMapping>,
+) {
+
+    private val validationDirectiveMappings = validationDirectiveMappings.sortedBy { it.directiveName }
+    private val mappingsByAnnotationClass: Map<KClass<out Annotation>, ValidationDirectiveMapping> =
+        validationDirectiveMappings.associateBy { it.annotationClass }
 
     fun transform(schema: GraphQLSchema, mutations: List<Mutation>, queries: List<Query>): GraphQLSchema {
         val appliedDirectivesMap = buildAppliedDirectivesMap(mutations, queries)

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/CreateStandaloneDocumentMutationTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/CreateStandaloneDocumentMutationTest.kt
@@ -77,7 +77,6 @@ class CreateStandaloneDocumentMutationTest(
             mustNotBeBlankTestCases("title") { value -> createStandaloneDocumentMutation(title = value) },
             sizeConstraintTestCases("title", maxLength = 255) { value -> createStandaloneDocumentMutation(title = value) },
             requiredFieldRejectedTestCases("documentId") { createStandaloneDocumentMutation() },
-            requiredFieldRejectedTestCases("title") { createStandaloneDocumentMutation() },
             requiredFieldRejectedTestCases("workspaceId") { createStandaloneDocumentMutation() },
         ).flatten()
 

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/EditStandaloneDocumentMutationTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/api/standalonedocuments/EditStandaloneDocumentMutationTest.kt
@@ -88,7 +88,6 @@ class EditStandaloneDocumentMutationTest(
             sizeConstraintTestCases("title", maxLength = 255) { value -> editStandaloneDocumentMutation(title = value) },
             requiredFieldRejectedTestCases("documentId") { editStandaloneDocumentMutation() },
             requiredFieldRejectedTestCases("id") { editStandaloneDocumentMutation() },
-            requiredFieldRejectedTestCases("title") { editStandaloneDocumentMutation() },
             requiredFieldRejectedTestCases("workspaceId") { editStandaloneDocumentMutation() },
         ).flatten()
 

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/expenses/CreateExpenseFullStackTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/expenses/CreateExpenseFullStackTest.kt
@@ -326,9 +326,10 @@ class CreateExpenseFullStackTest : SaFullStackTestBase() {
         page.setupPreconditionsAndNavigateToCreatePage {
             saveButton.click()
 
-            // Server-side validation reports one missing required variable at a time;
-            // title is the first non-null variable in the mutation that is absent here
             title {
+                shouldHaveValidationError("This value is required and should not be blank")
+            }
+            originalAmount {
                 shouldHaveValidationError("This value is required")
             }
             shouldHaveNotifications { validationFailed() }
@@ -340,7 +341,6 @@ class CreateExpenseFullStackTest : SaFullStackTestBase() {
                 shouldNotHaveValidationErrors()
             }
 
-            // Fill title and verify that originalAmount validation error is returned on next save
             title { input.fill("Slurm supplies") }
             saveButton.click()
 

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/incomes/CreateIncomeFullStackTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/incomes/CreateIncomeFullStackTest.kt
@@ -351,9 +351,10 @@ class CreateIncomeFullStackTest : SaFullStackTestBase() {
         page.setupPreconditionsAndNavigateToCreatePage {
             saveButton.click()
 
-            // Server-side validation reports one missing required variable at a time;
-            // title is the first non-null variable in the mutation that is absent here.
             title {
+                shouldHaveValidationError("This value is required and should not be blank")
+            }
+            originalAmount {
                 shouldHaveValidationError("This value is required")
             }
             shouldHaveNotifications { validationFailed() }

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/incometaxpayments/CreateIncomeTaxPaymentFullStackTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/incometaxpayments/CreateIncomeTaxPaymentFullStackTest.kt
@@ -177,6 +177,9 @@ class CreateIncomeTaxPaymentFullStackTest : SaFullStackTestBase() {
             saveButton.click()
 
             title {
+                shouldHaveValidationError("This value is required and should not be blank")
+            }
+            amount {
                 shouldHaveValidationError("This value is required")
             }
             shouldHaveNotifications { validationFailed() }

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/invoices/CreateInvoiceFullStackTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/business/ui/user/invoices/CreateInvoiceFullStackTest.kt
@@ -232,8 +232,16 @@ class CreateInvoiceFullStackTest : SaFullStackTestBase() {
         page.setupPreconditionsAndNavigateToCreatePage {
             saveButton.click()
 
-            // Server-side validation reports one missing required variable at a time.
             customer {
+                shouldHaveValidationError("This value is required")
+            }
+            title {
+                shouldHaveValidationError("This value is required and should not be blank")
+            }
+            dueDate {
+                shouldHaveValidationError("This value is required")
+            }
+            amount {
                 shouldHaveValidationError("This value is required")
             }
             shouldHaveNotifications { validationFailed() }
@@ -249,7 +257,7 @@ class CreateInvoiceFullStackTest : SaFullStackTestBase() {
             saveButton.click()
 
             title {
-                shouldHaveValidationError("This value is required")
+                shouldHaveValidationError("This value is required and should not be blank")
             }
             shouldHaveNotifications { validationFailed() }
 

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/infra/graphql/SaGraphQLNullFieldValidationInstrumentationTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/infra/graphql/SaGraphQLNullFieldValidationInstrumentationTest.kt
@@ -31,7 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired
  * 3. Typed GraphQL variable declared as non-null but supplied as `null` in the variables map
  *    (e.g. `$rateInBps: Int!` with `{"rateInBps": null}`).
  *
-     * Cases 1 and 2 produce a [graphql.validation.ValidationError]. Case 3 is handled by
+ * Cases 1 and 2 produce a [graphql.validation.ValidationError]. Case 3 is handled by
      * pre-coercion validation so it can report all variable violations before graphql-java's
      * fail-fast coercion path runs.
  */

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/infra/graphql/SaGraphQLNullFieldValidationInstrumentationTest.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/infra/graphql/SaGraphQLNullFieldValidationInstrumentationTest.kt
@@ -2,10 +2,18 @@ package io.orangebuffalo.simpleaccounting.infra.graphql
 
 import io.orangebuffalo.simpleaccounting.SaIntegrationTestBase
 import io.orangebuffalo.simpleaccounting.tests.infra.api.ApiTestClient
+import io.orangebuffalo.simpleaccounting.tests.infra.api.expectThatJsonBody
 import io.orangebuffalo.simpleaccounting.tests.infra.api.graphqlRawQuery
 import io.orangebuffalo.simpleaccounting.tests.infra.api.graphqlRawQueryWithVariables
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -23,10 +31,9 @@ import org.springframework.beans.factory.annotation.Autowired
  * 3. Typed GraphQL variable declared as non-null but supplied as `null` in the variables map
  *    (e.g. `$rateInBps: Int!` with `{"rateInBps": null}`).
  *
- * Cases 1 and 2 produce a [graphql.validation.ValidationError] and already carry the mutation
- * field path. Case 3 produces a [graphql.execution.NonNullableValueCoercedAsNullException] during
- * variable coercion, which does not carry a mutation path, so the transformed error's `path`
- * is an empty array.
+     * Cases 1 and 2 produce a [graphql.validation.ValidationError]. Case 3 is handled by
+     * pre-coercion validation so it can report all variable violations before graphql-java's
+     * fail-fast coercion path runs.
  */
 @DisplayName("SaGraphQLNullFieldValidationInstrumentation")
 class SaGraphQLNullFieldValidationInstrumentationTest(
@@ -101,10 +108,8 @@ class SaGraphQLNullFieldValidationInstrumentationTest(
         @Test
         fun `should transform null top-level variable for non-null type into FIELD_VALIDATION_FAILURE`() {
             // The variable $rateInBps is declared as Int! (non-null) but null is supplied in the
-            // variables map. graphql-java raises NonNullableValueCoercedAsNullException during
-            // variable coercion, which the instrumentation must transform the same way as inline
-            // null literals. Because coercion happens before execution, no mutation path is
-            // available, so the error's path is an empty array.
+            // variables map. Pre-coercion validation must transform it the same way as inline
+            // null literals, before graphql-java's fail-fast variable coercion runs.
             client.graphqlRawQueryWithVariables(
                 query = """
                 mutation(${'$'}rateInBps: Int!) {
@@ -120,10 +125,140 @@ class SaGraphQLNullFieldValidationInstrumentationTest(
                     violationPath = "rateInBps",
                     error = "MustNotBeNull",
                     message = "must not be null",
-                    paths = emptyList(),
+                    path = DgsConstants.MUTATION.CreateGeneralTax,
                     locationLine = 1,
                     locationColumn = 10,
                 )
+        }
+
+        @Test
+        fun `should report all null non-null argument variables`() {
+            client.graphqlRawQueryWithVariables(
+                query = """
+                mutation(${'$'}name: String!, ${'$'}defaultCurrency: String!) {
+                  createWorkspace(name: ${'$'}name, defaultCurrency: ${'$'}defaultCurrency) {
+                    id
+                  }
+                }
+                """.trimIndent(),
+                variables = buildJsonObject {
+                    put("name", JsonNull)
+                    put("defaultCurrency", JsonNull)
+                },
+            )
+                .from(preconditions.fry)
+                .execute()
+                .expectStatus().isOk
+                .expectThatJsonBody {
+                    val response = Json.parseToJsonElement(this).jsonObject
+                    val error = response["errors"]!!.jsonArray.single().jsonObject
+                    error["message"]!!.jsonPrimitive.content.shouldBe("Validation failed")
+                    error["extensions"]!!.jsonObject["errorType"]!!.jsonPrimitive.content
+                        .shouldBe("FIELD_VALIDATION_FAILURE")
+
+                    val validationErrors = error["extensions"]!!.jsonObject["validationErrors"]!!
+                        .jsonArray
+                        .map { it.jsonObject }
+                    withClue("Should report all null fields in one response") {
+                        validationErrors.map { it["path"]!!.jsonPrimitive.content }
+                            .shouldContainExactly("name", "defaultCurrency")
+                    }
+                    validationErrors.forEach { validationError ->
+                        validationError["error"]!!.jsonPrimitive.content.shouldBe("MustNotBeBlank")
+                        validationError["message"]!!.jsonPrimitive.content.shouldBe("must not be blank")
+                    }
+                }
+        }
+
+        @Test
+        fun `should report nullability and directive validation errors together`() {
+            client.graphqlRawQueryWithVariables(
+                query = """
+                mutation(${'$'}name: String!, ${'$'}defaultCurrency: String!) {
+                  createWorkspace(name: ${'$'}name, defaultCurrency: ${'$'}defaultCurrency) {
+                    id
+                  }
+                }
+                """.trimIndent(),
+                variables = buildJsonObject {
+                    put("name", JsonNull)
+                    put("defaultCurrency", "")
+                },
+            )
+                .from(preconditions.fry)
+                .execute()
+                .expectStatus().isOk
+                .expectThatJsonBody {
+                    val response = Json.parseToJsonElement(this).jsonObject
+                    val error = response["errors"]!!.jsonArray.single().jsonObject
+                    error["message"]!!.jsonPrimitive.content.shouldBe("Validation failed")
+                    error["extensions"]!!.jsonObject["errorType"]!!.jsonPrimitive.content
+                        .shouldBe("FIELD_VALIDATION_FAILURE")
+
+                    val validationErrors = error["extensions"]!!.jsonObject["validationErrors"]!!
+                        .jsonArray
+                        .map { it.jsonObject }
+                    validationErrors.map {
+                        it["path"]!!.jsonPrimitive.content to it["error"]!!.jsonPrimitive.content
+                    }.shouldContainExactly(
+                        "name" to "MustNotBeBlank",
+                        "defaultCurrency" to "MustNotBeBlank",
+                    )
+                }
+        }
+
+        @Test
+        fun `should report size validation errors for variables`() {
+            client.graphqlRawQueryWithVariables(
+                query = """
+                mutation(${'$'}name: String!, ${'$'}defaultCurrency: String!) {
+                  createWorkspace(name: ${'$'}name, defaultCurrency: ${'$'}defaultCurrency) {
+                    id
+                  }
+                }
+                """.trimIndent(),
+                variables = buildJsonObject {
+                    put("name", "Planet Express")
+                    put("defaultCurrency", "USDD")
+                },
+            )
+                .from(preconditions.fry)
+                .execute()
+                .expectStatus().isOk
+                .expectThatJsonBody {
+                    val response = Json.parseToJsonElement(this).jsonObject
+                    val validationError = response["errors"]!!
+                        .jsonArray.single().jsonObject["extensions"]!!.jsonObject["validationErrors"]!!
+                        .jsonArray.single().jsonObject
+
+                    validationError["path"]!!.jsonPrimitive.content.shouldBe("defaultCurrency")
+                    validationError["error"]!!.jsonPrimitive.content.shouldBe("SizeConstraintViolated")
+                    validationError["message"]!!.jsonPrimitive.content.shouldBe("size must be between 0 and 3")
+                }
+        }
+
+        @Test
+        fun `should accept false boolean literal for required field`() {
+            client.graphqlRawQuery(
+                """
+                mutation {
+                  createCategory(workspaceId: "${preconditions.workspace.id}", name: "Robot oil", income: false, expense: true) {
+                    income
+                    expense
+                  }
+                }
+                """.trimIndent()
+            )
+                .from(preconditions.fry)
+                .execute()
+                .expectStatus().isOk
+                .expectThatJsonBody {
+                    val response = Json.parseToJsonElement(this).jsonObject
+                    response["errors"].shouldBe(null)
+                    val category = response["data"]!!.jsonObject["createCategory"]!!.jsonObject
+                    category["income"]!!.jsonPrimitive.content.shouldBe("false")
+                    category["expense"]!!.jsonPrimitive.content.shouldBe("true")
+                }
         }
     }
 }

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/tests/infra/api/ApiTestsUtils.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/tests/infra/api/ApiTestsUtils.kt
@@ -476,8 +476,8 @@ class GraphqlClientRequestExecutor(
             )
             is GraphqlMutationRejectedInputTestCase -> executeAndVerifyValidationError(
                 violationPath = testCase.fieldName,
-                error = "MustNotBeNull",
-                message = "must not be null",
+                error = testCase.error,
+                message = testCase.message,
                 path = path,
             )
             is GraphqlMutationValidBoundaryTestCase -> {

--- a/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/tests/infra/api/GraphqlApiValidationUtils.kt
+++ b/app/src/test/kotlin/io/orangebuffalo/simpleaccounting/tests/infra/api/GraphqlApiValidationUtils.kt
@@ -46,8 +46,8 @@ data class GraphqlMutationValidationErrorTestCase(
  * bypassing DGS type-safe builder's null checks.
  *
  * The assertion verifies that the response contains a `FIELD_VALIDATION_FAILURE` error
- * with a `MustNotBeNull` error code for the given [fieldName]. This mirrors the same
- * validation error structure used for JSR-303 constraint violations.
+ * for the given [fieldName]. This mirrors the same validation error structure used for
+ * JSR-303 constraint violations.
  *
  * @property rawQueryBuilder lazily builds the raw GraphQL query with null for the target field.
  *   Lazy to avoid accessing test preconditions during test discovery (JUnit `@MethodSource`).
@@ -57,6 +57,8 @@ data class GraphqlMutationRejectedInputTestCase(
     override val description: String,
     val rawQueryBuilder: () -> String,
     val fieldName: String,
+    val error: String = "MustNotBeNull",
+    val message: String = "must not be null",
 ) : GraphqlMutationInputTestCase {
     override fun toString() = description
 }
@@ -100,8 +102,8 @@ data class GraphqlMutationOptionalFieldAbsentTestCase(
 
 /**
  * Generates test cases for `@NotBlank` string field validation. Produces:
- * - **null** input → `FIELD_VALIDATION_FAILURE` with `MustNotBeNull` error code
- * - **absent** input → `FIELD_VALIDATION_FAILURE` with `MustNotBeNull` error code
+ * - **null** input → `FIELD_VALIDATION_FAILURE` with `MustNotBeBlank` error code
+ * - **absent** input → `FIELD_VALIDATION_FAILURE` with `MustNotBeBlank` error code
  * - **blank** input (`"  "`) → `FIELD_VALIDATION_FAILURE` with `MustNotBeBlank`
  * - **empty** input (`""`) → `FIELD_VALIDATION_FAILURE` with `MustNotBeBlank`
  * - **min valid length** boundary → fully successful execution
@@ -124,6 +126,8 @@ fun mustNotBeBlankTestCases(
         GraphqlMutationRejectedInputTestCase(
             description = "$fieldName is null",
             fieldName = fieldName,
+            error = "MustNotBeBlank",
+            message = "must not be blank",
             rawQueryBuilder = {
                 buildRawMutationQueryWithNullField(fieldName) { mutationWithFieldValue("validPlaceholder") }
             },
@@ -131,6 +135,8 @@ fun mustNotBeBlankTestCases(
         GraphqlMutationRejectedInputTestCase(
             description = "$fieldName is absent",
             fieldName = fieldName,
+            error = "MustNotBeBlank",
+            message = "must not be blank",
             rawQueryBuilder = {
                 buildRawMutationQueryWithAbsentField(fieldName) { mutationWithFieldValue("validPlaceholder") }
             },


### PR DESCRIPTION
## Problem statement

GraphQL variable coercion stops on the first null non-null variable, which prevents clients from receiving all validation errors in one response.

## Solution summary

Add pre-coercion GraphQL input validation that maps nullability and validation-directive failures into the existing field validation error shape. Refactor validation directives into Spring-discovered mappings and update API/full-stack tests for aggregated validation behavior.

## Notes

Includes a small KDoc indentation cleanup in the GraphQL validation instrumentation test.
